### PR TITLE
[Feat] expand coverage for patch and mailbox workflows

### DIFF
--- a/.codex/skills/criew-development/SKILL.md
+++ b/.codex/skills/criew-development/SKILL.md
@@ -78,6 +78,13 @@ For larger commits, add a body with bullet points that summarize the main change
 
 Run the full repository validation set after non-trivial changes when the environment allows it.
 
+- Keep overall repository coverage at or above 70%.
+- Keep newly added code at or above 80% coverage.
+- Keep critical-component coverage at or above 85% for critical workflow code that the current change directly touches or materially expands. Treat sync, reply, patch, and other core user-facing workflow paths in scope as critical unless the task clearly falls outside those paths.
+- Do not add tests only to tick uncovered lines. Coverage work must defend a real behavior, regression, failure mode, or workflow contract that matters to users or operators.
+- Prefer behavior-driven regression tests over line-chasing. If a remaining gap is not worth a brittle or artificial test, leave it uncovered and report the tradeoff clearly.
+- Use `./scripts/check-coverage.sh` plus the generated summary report to verify the thresholds above, and review file-level or workflow-level reports for the in-scope critical components. Treat threshold regressions as incomplete work.
+
 - `cargo fmt --all -- --check`
 - `cargo clippy --all-targets --all-features -- -D warnings`
 - `cargo test --all-targets --all-features`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,17 +7,25 @@ pub mod cli;
 pub mod patch;
 pub mod sync;
 
+use std::path::PathBuf;
+
 use clap::Parser;
 
 use crate::infra::b4::{self, B4Status};
 use crate::infra::bootstrap;
 use crate::infra::config::{self, IMAP_INBOX_MAILBOX};
 use crate::infra::error::Result;
-use crate::infra::imap::{ImapClient, RemoteImapClient};
+use crate::infra::imap::{ImapClient, MailboxSnapshot, RemoteImapClient};
 use crate::infra::logging;
-use crate::infra::sendmail::{self, GitSendEmailStatus};
+use crate::infra::sendmail::{self, GitSendEmailCheck, GitSendEmailStatus, ReplyIdentity};
 
 const DEFAULT_SYNC_RECONNECT_ATTEMPTS: u8 = 3;
+
+enum DoctorImapStatus {
+    Skipped(Vec<String>),
+    Connected(MailboxSnapshot),
+    Error(String),
+}
 
 pub fn run() -> Result<()> {
     let cli = cli::Cli::parse();
@@ -55,12 +63,13 @@ pub fn run() -> Result<()> {
             uidvalidity,
             reconnect_attempts,
         } => {
-            let request = sync::SyncRequest {
-                mailbox: mailbox.unwrap_or_else(|| runtime.source_mailbox.clone()),
+            let request = build_sync_request(
+                &runtime,
+                mailbox,
                 fixture_dir,
                 uidvalidity,
-                reconnect_attempts: reconnect_attempts.unwrap_or(DEFAULT_SYNC_RECONNECT_ATTEMPTS),
-            };
+                reconnect_attempts,
+            );
             run_sync_command(&runtime, &bootstrap_state, request, true)?;
             Ok(())
         }
@@ -109,120 +118,19 @@ pub fn run() -> Result<()> {
                 bootstrap_state.db.created
             );
             let self_email = config::resolve_self_email(&runtime);
+            let imap_status = probe_doctor_imap(&runtime);
             println!(
-                "  self_email: {}",
-                self_email.email.as_deref().unwrap_or("<missing>")
+                "{}",
+                format_doctor_report(
+                    &runtime,
+                    &bootstrap_state,
+                    &self_email,
+                    &imap_status,
+                    &send_email_status,
+                    &reply_identity,
+                    &b4_status,
+                )
             );
-            println!(
-                "  self_email_source: {}",
-                self_email
-                    .source
-                    .map(|source| source.as_str())
-                    .unwrap_or("<none>")
-            );
-            if let Some(error) = self_email.git_error.as_deref() {
-                println!("  self_email_lookup: error ({error})");
-            }
-            println!(
-                "  imap_config_status: {}",
-                if runtime.imap.is_complete() {
-                    "complete"
-                } else {
-                    "incomplete"
-                }
-            );
-            if runtime.imap.is_complete() {
-                println!(
-                    "  imap_connection_target: {}:{} ({})",
-                    runtime.imap.server.as_deref().unwrap_or("<missing>"),
-                    runtime.imap.server_port.unwrap_or_default(),
-                    runtime
-                        .imap
-                        .encryption
-                        .map(|value| value.as_str())
-                        .unwrap_or("<missing>")
-                );
-
-                match RemoteImapClient::new(runtime.imap.clone()).and_then(|mut client| {
-                    client.connect()?;
-                    client.select_mailbox(IMAP_INBOX_MAILBOX)
-                }) {
-                    Ok(snapshot) => {
-                        println!("  imap_connect_status: ok");
-                        println!("  imap_select_mailbox: {}", IMAP_INBOX_MAILBOX);
-                        println!("  imap_uidvalidity: {}", snapshot.uidvalidity);
-                        println!("  imap_highest_uid: {}", snapshot.highest_uid);
-                        println!(
-                            "  imap_highest_modseq: {}",
-                            snapshot
-                                .highest_modseq
-                                .map(|value| value.to_string())
-                                .unwrap_or_else(|| "<none>".to_string())
-                        );
-                    }
-                    Err(error) => {
-                        println!("  imap_connect_status: error ({error})");
-                    }
-                }
-            } else {
-                let missing = runtime.imap.missing_required_fields();
-                println!(
-                    "  imap_missing_fields: {}",
-                    if missing.is_empty() {
-                        "<none>".to_string()
-                    } else {
-                        missing.join(", ")
-                    }
-                );
-                println!("  imap_connect_status: skipped");
-            }
-
-            match send_email_status.status {
-                GitSendEmailStatus::Available { path, version } => {
-                    println!("  git_send_email_path: {}", path.display());
-                    println!("  git_send_email_version: {}", version);
-                    println!("  git_send_email_status: ok");
-                }
-                GitSendEmailStatus::Broken { path, reason } => {
-                    println!("  git_send_email_path: {}", path.display());
-                    println!("  git_send_email_status: broken ({reason})");
-                }
-                GitSendEmailStatus::Missing => {
-                    println!("  git_send_email_path: <not found>");
-                    println!("  git_send_email_status: missing");
-                }
-            }
-
-            match reply_identity {
-                Ok(identity) => {
-                    println!("  reply_from: {}", identity.display);
-                    println!("  reply_from_email: {}", identity.email);
-                    println!("  reply_from_source: {}", identity.source.as_str());
-                    println!("  reply_identity_status: ok");
-                }
-                Err(error) => {
-                    println!("  reply_from: <missing>");
-                    println!("  reply_from_email: <missing>");
-                    println!("  reply_from_source: <none>");
-                    println!("  reply_identity_status: error ({error})");
-                }
-            }
-
-            match b4_status.status {
-                B4Status::Available { path, version } => {
-                    println!("  b4_path: {}", path.display());
-                    println!("  b4_version: {}", version);
-                    println!("  b4_status: ok");
-                }
-                B4Status::Broken { path, reason } => {
-                    println!("  b4_path: {}", path.display());
-                    println!("  b4_status: broken ({reason})");
-                }
-                B4Status::Missing => {
-                    println!("  b4_path: <not found>");
-                    println!("  b4_status: missing");
-                }
-            }
 
             Ok(())
         }
@@ -250,24 +158,480 @@ fn run_sync_command(
     );
 
     if print_summary {
-        println!(
-            "sync complete: mailbox={} source={} fetched={} inserted={} updated={} rebuilt_roots={} uidvalidity={} last_seen_uid={} highest_modseq={:?} synced_at={} mailbox_rebuilt={}",
-            summary.mailbox,
-            summary.source,
-            summary.fetched,
-            summary.inserted,
-            summary.updated,
-            summary.rebuilt_roots,
-            summary.uidvalidity,
-            summary.checkpoint_last_seen_uid,
-            summary.checkpoint_highest_modseq,
-            summary
-                .checkpoint_synced_at
-                .as_deref()
-                .unwrap_or("<unknown>"),
-            summary.mailbox_rebuilt
-        );
+        println!("{}", format_sync_summary(&summary));
     }
 
     Ok(summary)
+}
+
+fn build_sync_request(
+    runtime: &config::RuntimeConfig,
+    mailbox: Option<String>,
+    fixture_dir: Option<PathBuf>,
+    uidvalidity: Option<u64>,
+    reconnect_attempts: Option<u8>,
+) -> sync::SyncRequest {
+    sync::SyncRequest {
+        mailbox: mailbox.unwrap_or_else(|| runtime.source_mailbox.clone()),
+        fixture_dir,
+        uidvalidity,
+        reconnect_attempts: reconnect_attempts.unwrap_or(DEFAULT_SYNC_RECONNECT_ATTEMPTS),
+    }
+}
+
+fn probe_doctor_imap(runtime: &config::RuntimeConfig) -> DoctorImapStatus {
+    if !runtime.imap.is_complete() {
+        return DoctorImapStatus::Skipped(
+            runtime
+                .imap
+                .missing_required_fields()
+                .into_iter()
+                .map(ToOwned::to_owned)
+                .collect(),
+        );
+    }
+
+    match RemoteImapClient::new(runtime.imap.clone()).and_then(|mut client| {
+        client.connect()?;
+        client.select_mailbox(IMAP_INBOX_MAILBOX)
+    }) {
+        Ok(snapshot) => DoctorImapStatus::Connected(snapshot),
+        Err(error) => DoctorImapStatus::Error(error.to_string()),
+    }
+}
+
+fn format_doctor_report(
+    runtime: &config::RuntimeConfig,
+    bootstrap_state: &bootstrap::BootstrapState,
+    self_email: &config::SelfEmailResolution,
+    imap_status: &DoctorImapStatus,
+    send_email_status: &GitSendEmailCheck,
+    reply_identity: &std::result::Result<ReplyIdentity, String>,
+    b4_status: &b4::B4Check,
+) -> String {
+    let mut lines = vec![
+        "criew doctor".to_string(),
+        format!("  config_path: {}", runtime.config_path.display()),
+        format!("  data_dir: {}", runtime.data_dir.display()),
+        format!("  database_path: {}", runtime.database_path.display()),
+        format!("  raw_mail_dir: {}", runtime.raw_mail_dir.display()),
+        format!("  patch_dir: {}", runtime.patch_dir.display()),
+        format!("  log_dir: {}", runtime.log_dir.display()),
+        format!("  source_mailbox: {}", runtime.source_mailbox),
+        format!(
+            "  default_active_mailbox: {}",
+            runtime.default_active_mailbox()
+        ),
+        format!("  lore_base_url: {}", runtime.lore_base_url),
+        format!("  startup_sync: {}", runtime.startup_sync),
+        format!(
+            "  inbox_auto_sync_interval_secs: {}",
+            runtime.inbox_auto_sync_interval_secs
+        ),
+    ];
+    if runtime.kernel_trees.is_empty() {
+        lines.push("  kernel_trees: <none>".to_string());
+    } else {
+        lines.extend(
+            runtime
+                .kernel_trees
+                .iter()
+                .map(|tree| format!("  kernel_tree: {}", tree.display())),
+        );
+    }
+    lines.push(format!(
+        "  schema_version: {}",
+        bootstrap_state.db.schema_version
+    ));
+    lines.push(format!(
+        "  schema_version_expected: {}",
+        crate::infra::db::CURRENT_SCHEMA_VERSION
+    ));
+    lines.push(format!(
+        "  migrations_applied: {:?}",
+        bootstrap_state.db.applied_migrations
+    ));
+    lines.push(format!(
+        "  database_created_this_run: {}",
+        bootstrap_state.db.created
+    ));
+    lines.push(format!(
+        "  self_email: {}",
+        self_email.email.as_deref().unwrap_or("<missing>")
+    ));
+    lines.push(format!(
+        "  self_email_source: {}",
+        self_email
+            .source
+            .map(|source| source.as_str())
+            .unwrap_or("<none>")
+    ));
+    if let Some(error) = self_email.git_error.as_deref() {
+        lines.push(format!("  self_email_lookup: error ({error})"));
+    }
+    lines.push(format!(
+        "  imap_config_status: {}",
+        if runtime.imap.is_complete() {
+            "complete"
+        } else {
+            "incomplete"
+        }
+    ));
+    match imap_status {
+        DoctorImapStatus::Skipped(missing_fields) => {
+            lines.push(format!(
+                "  imap_missing_fields: {}",
+                if missing_fields.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    missing_fields.join(", ")
+                }
+            ));
+            lines.push("  imap_connect_status: skipped".to_string());
+        }
+        DoctorImapStatus::Connected(snapshot) => {
+            lines.push(format!(
+                "  imap_connection_target: {}:{} ({})",
+                runtime.imap.server.as_deref().unwrap_or("<missing>"),
+                runtime.imap.server_port.unwrap_or_default(),
+                runtime
+                    .imap
+                    .encryption
+                    .map(|value| value.as_str())
+                    .unwrap_or("<missing>")
+            ));
+            lines.push("  imap_connect_status: ok".to_string());
+            lines.push(format!("  imap_select_mailbox: {}", IMAP_INBOX_MAILBOX));
+            lines.push(format!("  imap_uidvalidity: {}", snapshot.uidvalidity));
+            lines.push(format!("  imap_highest_uid: {}", snapshot.highest_uid));
+            lines.push(format!(
+                "  imap_highest_modseq: {}",
+                snapshot
+                    .highest_modseq
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "<none>".to_string())
+            ));
+        }
+        DoctorImapStatus::Error(error) => {
+            lines.push(format!(
+                "  imap_connection_target: {}:{} ({})",
+                runtime.imap.server.as_deref().unwrap_or("<missing>"),
+                runtime.imap.server_port.unwrap_or_default(),
+                runtime
+                    .imap
+                    .encryption
+                    .map(|value| value.as_str())
+                    .unwrap_or("<missing>")
+            ));
+            lines.push(format!("  imap_connect_status: error ({error})"));
+        }
+    }
+    match &send_email_status.status {
+        GitSendEmailStatus::Available { path, version } => {
+            lines.push(format!("  git_send_email_path: {}", path.display()));
+            lines.push(format!("  git_send_email_version: {}", version));
+            lines.push("  git_send_email_status: ok".to_string());
+        }
+        GitSendEmailStatus::Broken { path, reason } => {
+            lines.push(format!("  git_send_email_path: {}", path.display()));
+            lines.push(format!("  git_send_email_status: broken ({reason})"));
+        }
+        GitSendEmailStatus::Missing => {
+            lines.push("  git_send_email_path: <not found>".to_string());
+            lines.push("  git_send_email_status: missing".to_string());
+        }
+    }
+    match reply_identity {
+        Ok(identity) => {
+            lines.push(format!("  reply_from: {}", identity.display));
+            lines.push(format!("  reply_from_email: {}", identity.email));
+            lines.push(format!("  reply_from_source: {}", identity.source.as_str()));
+            lines.push("  reply_identity_status: ok".to_string());
+        }
+        Err(error) => {
+            lines.push("  reply_from: <missing>".to_string());
+            lines.push("  reply_from_email: <missing>".to_string());
+            lines.push("  reply_from_source: <none>".to_string());
+            lines.push(format!("  reply_identity_status: error ({error})"));
+        }
+    }
+    match &b4_status.status {
+        B4Status::Available { path, version } => {
+            lines.push(format!("  b4_path: {}", path.display()));
+            lines.push(format!("  b4_version: {}", version));
+            lines.push("  b4_status: ok".to_string());
+        }
+        B4Status::Broken { path, reason } => {
+            lines.push(format!("  b4_path: {}", path.display()));
+            lines.push(format!("  b4_status: broken ({reason})"));
+        }
+        B4Status::Missing => {
+            lines.push("  b4_path: <not found>".to_string());
+            lines.push("  b4_status: missing".to_string());
+        }
+    }
+    lines.join("\n")
+}
+
+fn format_sync_summary(summary: &sync::SyncSummary) -> String {
+    format!(
+        "sync complete: mailbox={} source={} fetched={} inserted={} updated={} rebuilt_roots={} uidvalidity={} last_seen_uid={} highest_modseq={:?} synced_at={} mailbox_rebuilt={}",
+        summary.mailbox,
+        summary.source,
+        summary.fetched,
+        summary.inserted,
+        summary.updated,
+        summary.rebuilt_roots,
+        summary.uidvalidity,
+        summary.checkpoint_last_seen_uid,
+        summary.checkpoint_highest_modseq,
+        summary
+            .checkpoint_synced_at
+            .as_deref()
+            .unwrap_or("<unknown>"),
+        summary.mailbox_rebuilt
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::infra::b4::B4Status;
+    use crate::infra::bootstrap::BootstrapState;
+    use crate::infra::config::{
+        DEFAULT_INBOX_AUTO_SYNC_INTERVAL_SECS, ImapConfig, ImapEncryption, RuntimeConfig,
+        SelfEmailResolution, SelfEmailSource, UiKeymap,
+    };
+    use crate::infra::db::DatabaseState;
+    use crate::infra::imap::MailboxSnapshot;
+    use crate::infra::sendmail::{
+        GitSendEmailCheck, GitSendEmailStatus, ReplyIdentity, ReplyIdentitySource,
+    };
+
+    use super::{
+        DoctorImapStatus, build_sync_request, format_doctor_report, format_sync_summary,
+        probe_doctor_imap,
+    };
+
+    fn test_runtime() -> RuntimeConfig {
+        RuntimeConfig {
+            config_path: PathBuf::from("/tmp/criew-config.toml"),
+            data_dir: PathBuf::from("/tmp/criew"),
+            database_path: PathBuf::from("/tmp/criew/criew.db"),
+            raw_mail_dir: PathBuf::from("/tmp/criew/raw"),
+            patch_dir: PathBuf::from("/tmp/criew/patches"),
+            log_dir: PathBuf::from("/tmp/criew/logs"),
+            b4_path: None,
+            log_filter: "info".to_string(),
+            source_mailbox: "linux-kernel".to_string(),
+            imap: ImapConfig::default(),
+            lore_base_url: "https://lore.kernel.org".to_string(),
+            startup_sync: true,
+            ui_keymap: UiKeymap::Default,
+            inbox_auto_sync_interval_secs: DEFAULT_INBOX_AUTO_SYNC_INTERVAL_SECS,
+            kernel_trees: Vec::new(),
+        }
+    }
+
+    fn test_bootstrap_state() -> BootstrapState {
+        BootstrapState {
+            db: DatabaseState {
+                path: PathBuf::from("/tmp/criew/criew.db"),
+                schema_version: crate::infra::db::CURRENT_SCHEMA_VERSION,
+                created: false,
+                applied_migrations: vec![1, 2, 3, crate::infra::db::CURRENT_SCHEMA_VERSION],
+            },
+        }
+    }
+
+    #[test]
+    fn build_sync_request_uses_runtime_defaults_and_overrides() {
+        let runtime = test_runtime();
+
+        let default_request = build_sync_request(&runtime, None, None, None, None);
+        assert_eq!(default_request.mailbox, "linux-kernel");
+        assert_eq!(
+            default_request.reconnect_attempts,
+            super::DEFAULT_SYNC_RECONNECT_ATTEMPTS
+        );
+
+        let overridden_request = build_sync_request(
+            &runtime,
+            Some("INBOX".to_string()),
+            Some(PathBuf::from("/tmp/fixtures")),
+            Some(42),
+            Some(7),
+        );
+        assert_eq!(overridden_request.mailbox, "INBOX");
+        assert_eq!(
+            overridden_request.fixture_dir,
+            Some(PathBuf::from("/tmp/fixtures"))
+        );
+        assert_eq!(overridden_request.uidvalidity, Some(42));
+        assert_eq!(overridden_request.reconnect_attempts, 7);
+    }
+
+    #[test]
+    fn format_sync_summary_renders_unknown_synced_at_fallback() {
+        let summary = crate::app::sync::SyncSummary {
+            mailbox: "linux-kernel".to_string(),
+            source: "fixture".to_string(),
+            fetched: 3,
+            inserted: 2,
+            updated: 1,
+            rebuilt_roots: 4,
+            mailbox_rebuilt: false,
+            uidvalidity: 11,
+            checkpoint_last_seen_uid: 99,
+            checkpoint_highest_modseq: Some(123),
+            checkpoint_synced_at: None,
+        };
+
+        let rendered = format_sync_summary(&summary);
+
+        assert!(rendered.contains("mailbox=linux-kernel"));
+        assert!(rendered.contains("source=fixture"));
+        assert!(rendered.contains("synced_at=<unknown>"));
+    }
+
+    #[test]
+    fn format_doctor_report_covers_incomplete_imap_and_missing_tools() {
+        let runtime = test_runtime();
+        let self_email = SelfEmailResolution {
+            email: None,
+            source: None,
+            git_error: Some("git config failed".to_string()),
+        };
+        let report = format_doctor_report(
+            &runtime,
+            &test_bootstrap_state(),
+            &self_email,
+            &DoctorImapStatus::Skipped(vec!["imap.user".to_string(), "imap.pass".to_string()]),
+            &GitSendEmailCheck {
+                status: GitSendEmailStatus::Missing,
+            },
+            &Err("missing reply identity".to_string()),
+            &crate::infra::b4::B4Check {
+                status: B4Status::Missing,
+            },
+        );
+
+        assert!(report.contains("criew doctor"));
+        assert!(report.contains("kernel_trees: <none>"));
+        assert!(report.contains("self_email_lookup: error (git config failed)"));
+        assert!(report.contains("imap_config_status: incomplete"));
+        assert!(report.contains("imap_missing_fields: imap.user, imap.pass"));
+        assert!(report.contains("imap_connect_status: skipped"));
+        assert!(report.contains("git_send_email_status: missing"));
+        assert!(report.contains("reply_identity_status: error (missing reply identity)"));
+        assert!(report.contains("b4_status: missing"));
+    }
+
+    #[test]
+    fn format_doctor_report_covers_connected_imap_and_available_tools() {
+        let mut runtime = test_runtime();
+        runtime.kernel_trees = vec![PathBuf::from("/tmp/linux")];
+        runtime.imap = ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(993),
+            encryption: Some(ImapEncryption::Tls),
+            proxy: None,
+        };
+        let self_email = SelfEmailResolution {
+            email: Some("me@example.com".to_string()),
+            source: Some(SelfEmailSource::CriewImapConfig),
+            git_error: None,
+        };
+        let report = format_doctor_report(
+            &runtime,
+            &test_bootstrap_state(),
+            &self_email,
+            &DoctorImapStatus::Connected(MailboxSnapshot {
+                uidvalidity: 7,
+                highest_uid: 88,
+                highest_modseq: Some(99),
+            }),
+            &GitSendEmailCheck {
+                status: GitSendEmailStatus::Available {
+                    path: PathBuf::from("/usr/bin/git"),
+                    version: "2.45".to_string(),
+                },
+            },
+            &Ok(ReplyIdentity {
+                display: "CRIEW <me@example.com>".to_string(),
+                email: "me@example.com".to_string(),
+                source: ReplyIdentitySource::SendEmailFrom,
+            }),
+            &crate::infra::b4::B4Check {
+                status: B4Status::Available {
+                    path: PathBuf::from("/usr/bin/b4"),
+                    version: "0.14".to_string(),
+                },
+            },
+        );
+
+        assert!(report.contains("kernel_tree: /tmp/linux"));
+        assert!(report.contains("imap_config_status: complete"));
+        assert!(report.contains("imap_connection_target: imap.example.com:993 (tls)"));
+        assert!(report.contains("imap_connect_status: ok"));
+        assert!(report.contains("imap_uidvalidity: 7"));
+        assert!(report.contains("git_send_email_status: ok"));
+        assert!(report.contains("reply_identity_status: ok"));
+        assert!(report.contains("b4_status: ok"));
+    }
+
+    #[test]
+    fn probe_doctor_imap_skips_incomplete_config_without_network_access() {
+        let status = probe_doctor_imap(&test_runtime());
+
+        match status {
+            DoctorImapStatus::Skipped(missing_fields) => {
+                assert!(missing_fields.contains(&"imap.user".to_string()));
+                assert!(missing_fields.contains(&"imap.pass".to_string()));
+            }
+            _ => panic!("expected incomplete IMAP config to skip probing"),
+        }
+    }
+
+    #[test]
+    fn format_doctor_report_covers_imap_error_and_broken_tools() {
+        let mut runtime = test_runtime();
+        runtime.imap = ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(993),
+            encryption: Some(ImapEncryption::Tls),
+            proxy: None,
+        };
+
+        let report = format_doctor_report(
+            &runtime,
+            &test_bootstrap_state(),
+            &SelfEmailResolution::default(),
+            &DoctorImapStatus::Error("connect failed".to_string()),
+            &GitSendEmailCheck {
+                status: GitSendEmailStatus::Broken {
+                    path: PathBuf::from("/usr/bin/git"),
+                    reason: "missing send-email".to_string(),
+                },
+            },
+            &Err("missing reply identity".to_string()),
+            &crate::infra::b4::B4Check {
+                status: B4Status::Broken {
+                    path: PathBuf::from("/usr/bin/b4"),
+                    reason: "bad runtime".to_string(),
+                },
+            },
+        );
+
+        assert!(report.contains("imap_connect_status: error (connect failed)"));
+        assert!(report.contains("git_send_email_status: broken (missing send-email)"));
+        assert!(report.contains("b4_status: broken (bad runtime)"));
+    }
 }

--- a/src/app/patch.rs
+++ b/src/app/patch.rs
@@ -1127,19 +1127,29 @@ fn format_seq(values: &[u32]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
-    use std::path::PathBuf;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
     use std::process::Command as ProcessCommand;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use rusqlite::{Connection, params};
+
+    use crate::domain::models::PatchSeriesStatus;
     use crate::infra::config::RuntimeConfig;
+    use crate::infra::db;
+    use crate::infra::error::ErrorCode;
     use crate::infra::mail_store::ThreadRow;
+    use crate::infra::patch_store;
 
     use super::{
         APPLY_ARTIFACTS_DIR, PatchAction, SeriesIntegrity, action_args, action_subcommand,
-        action_working_dir, build_series_index, download_series_name, parse_patch_subject,
-        parse_seq_total_token, parse_version_token, relocate_new_apply_artifacts,
-        snapshot_apply_artifacts, subject_is_patch_related, undo_last_apply,
+        action_working_dir, build_series_index, download_series_name, hydrate_series_statuses,
+        load_latest_report, parse_patch_subject, parse_seq_total_token, parse_version_token,
+        relocate_new_apply_artifacts, run_action, snapshot_apply_artifacts,
+        subject_is_patch_related, undo_last_apply,
     };
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -1147,7 +1157,10 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("criew-patch-{label}-{nonce}"));
+        let path = std::env::temp_dir().join(format!(
+            "criew-patch-{label}-{}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&path).expect("create temp dir");
         path
     }
@@ -1161,6 +1174,27 @@ mod tests {
             raw_mail_dir: root.join("data/raw"),
             patch_dir: root.join("data/patches"),
             log_dir: root.join("data/logs"),
+            b4_path: None,
+            log_filter: "info".to_string(),
+            source_mailbox: "io-uring".to_string(),
+            imap: crate::infra::config::ImapConfig::default(),
+            lore_base_url: "https://lore.kernel.org".to_string(),
+            startup_sync: true,
+            ui_keymap: crate::infra::config::UiKeymap::Default,
+            inbox_auto_sync_interval_secs:
+                crate::infra::config::DEFAULT_INBOX_AUTO_SYNC_INTERVAL_SECS,
+            kernel_trees,
+        }
+    }
+
+    fn runtime_in(root: &Path, kernel_trees: Vec<PathBuf>) -> RuntimeConfig {
+        RuntimeConfig {
+            config_path: root.join("config.toml"),
+            data_dir: root.join("data"),
+            database_path: root.join("data").join("criew.db"),
+            raw_mail_dir: root.join("data").join("raw"),
+            patch_dir: root.join("data").join("patches"),
+            log_dir: root.join("data").join("logs"),
             b4_path: None,
             log_filter: "info".to_string(),
             source_mailbox: "io-uring".to_string(),
@@ -1203,6 +1237,41 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn write_script(root: &Path, name: &str, body: &str) -> PathBuf {
+        let path = root.join(name);
+        fs::write(&path, body).expect("write script");
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).expect("mark executable");
+        }
+        path
+    }
+
+    fn seed_mail_rows(path: &Path, rows: &[(i64, &str)]) {
+        let connection = Connection::open(path).expect("open db");
+        for (id, message_id) in rows {
+            connection
+                .execute(
+                    "
+INSERT INTO mail(id, message_id, subject, from_addr, imap_mailbox, imap_uid)
+VALUES (?1, ?2, ?3, ?4, 'io-uring', ?1)
+",
+                    params![id, message_id, format!("subject-{id}"), "alice@example.com"],
+                )
+                .expect("insert mail row");
+        }
+    }
+
+    fn initialize_patch_runtime(runtime: &RuntimeConfig, mail_rows: &[(i64, &str)]) {
+        if let Some(parent) = runtime.database_path.parent() {
+            fs::create_dir_all(parent).expect("create db parent");
+        }
+        let _ = db::initialize(&runtime.database_path).expect("initialize db");
+        seed_mail_rows(&runtime.database_path, mail_rows);
     }
 
     fn thread_row(
@@ -1249,6 +1318,162 @@ mod tests {
             integrity: super::SeriesIntegrity::Complete,
             status: crate::domain::models::PatchSeriesStatus::New,
         }
+    }
+
+    #[test]
+    fn integrity_helpers_match_user_visible_patch_status_contract() {
+        let mut summary = sample_summary("[PATCH 1/1] io_uring: demo", 1);
+
+        assert_eq!(summary.present_count(), 1);
+        assert_eq!(summary.status_label(), "new");
+        assert_eq!(SeriesIntegrity::Complete.as_str(), "complete");
+        assert_eq!(SeriesIntegrity::Complete.short_label(), "ready");
+        assert!(SeriesIntegrity::Complete.is_ready());
+        assert_eq!(summary.integrity_reason(), None);
+
+        summary.integrity = SeriesIntegrity::Missing;
+        summary.missing_seq = vec![2, 4];
+        assert_eq!(summary.integrity.as_str(), "missing");
+        assert_eq!(summary.integrity.short_label(), "missing");
+        assert!(!summary.integrity.is_ready());
+        assert_eq!(
+            summary.integrity_reason().as_deref(),
+            Some("missing patch index: 2,4")
+        );
+
+        summary.integrity = SeriesIntegrity::Duplicate;
+        summary.duplicate_seq = vec![1];
+        assert_eq!(summary.integrity.as_str(), "duplicate");
+        assert_eq!(summary.integrity.short_label(), "duplicate");
+        assert_eq!(
+            summary.integrity_reason().as_deref(),
+            Some("duplicate patch index: 1")
+        );
+
+        summary.integrity = SeriesIntegrity::OutOfOrder;
+        assert_eq!(summary.integrity.as_str(), "out-of-order");
+        assert_eq!(summary.integrity.short_label(), "out-of-order");
+        assert_eq!(
+            summary.integrity_reason().as_deref(),
+            Some("patch order is out-of-order in thread")
+        );
+
+        summary.integrity = SeriesIntegrity::Invalid;
+        assert_eq!(summary.integrity.as_str(), "invalid");
+        assert_eq!(summary.integrity.short_label(), "invalid");
+        assert_eq!(
+            summary.integrity_reason().as_deref(),
+            Some("no valid [PATCH vN M/N] sequence found")
+        );
+
+        summary.status = PatchSeriesStatus::Conflict;
+        assert_eq!(summary.status_label(), "conflict");
+    }
+
+    #[test]
+    fn hydrate_series_statuses_overlays_only_visible_threads() {
+        let root = temp_dir("hydrate-status");
+        let runtime = runtime_in(&root, Vec::new());
+        initialize_patch_runtime(&runtime, &[(1, "patch@example.com")]);
+
+        let series = patch_store::upsert_series(
+            &runtime.database_path,
+            &patch_store::UpsertSeriesRequest {
+                mailbox: "io-uring".to_string(),
+                thread_id: 42,
+                version: 1,
+                expected_total: 1,
+                author: "Alice".to_string(),
+                subject: "demo".to_string(),
+                anchor_message_id: "patch@example.com".to_string(),
+                integrity: "complete".to_string(),
+                missing_seq: Vec::new(),
+                duplicate_seq: Vec::new(),
+                out_of_order: false,
+                items: vec![patch_store::UpsertSeriesItem {
+                    seq: 1,
+                    total: 1,
+                    mail_id: 1,
+                    message_id: "patch@example.com".to_string(),
+                    subject: "demo".to_string(),
+                    raw_path: None,
+                    sort_ord: 0,
+                }],
+            },
+        )
+        .expect("persist series");
+        patch_store::update_series_result(
+            &runtime.database_path,
+            series.id,
+            &patch_store::SeriesResultUpdate {
+                status: PatchSeriesStatus::Applied,
+                last_error: None,
+                last_command: Some("b4 am patch@example.com".to_string()),
+                last_exit_code: Some(0),
+                last_stdout: Some("applied".to_string()),
+                last_stderr: None,
+                output_path: None,
+            },
+        )
+        .expect("update series status");
+
+        let mut visible_summaries = HashMap::from([
+            (42, sample_summary("[PATCH 1/1] io_uring: demo", 1)),
+            (
+                99,
+                super::SeriesSummary {
+                    thread_id: 99,
+                    status: PatchSeriesStatus::Failed,
+                    ..sample_summary("[PATCH 1/1] io_uring: another", 1)
+                },
+            ),
+        ]);
+
+        hydrate_series_statuses(&runtime.database_path, "io-uring", &mut visible_summaries)
+            .expect("hydrate statuses");
+
+        assert_eq!(
+            visible_summaries.get(&42).map(|summary| summary.status),
+            Some(PatchSeriesStatus::Applied)
+        );
+        assert_eq!(
+            visible_summaries.get(&99).map(|summary| summary.status),
+            Some(PatchSeriesStatus::Failed)
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_latest_report_returns_none_when_thread_has_no_patch_state() {
+        let root = temp_dir("latest-report-none");
+        let runtime = runtime_in(&root, Vec::new());
+        initialize_patch_runtime(&runtime, &[]);
+
+        let report =
+            load_latest_report(&runtime.database_path, "io-uring", 42).expect("load latest report");
+        assert!(report.is_none());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_action_rejects_incomplete_series_before_persisting_or_running_b4() {
+        let root = temp_dir("reject-incomplete");
+        let runtime = runtime_in(&root, Vec::new());
+        let mut summary = sample_summary("[PATCH 1/2] io_uring: demo", 1);
+        summary.integrity = SeriesIntegrity::Missing;
+        summary.expected_total = 2;
+        summary.missing_seq = vec![2];
+
+        let error = run_action(&runtime, &summary, PatchAction::Apply).expect_err("reject apply");
+
+        assert_eq!(error.code(), ErrorCode::Command);
+        assert!(error.to_string().contains("cannot apply series"));
+        assert!(error.to_string().contains("missing patch index: 2"));
+        assert!(!runtime.database_path.exists());
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -1361,10 +1586,81 @@ mod tests {
     }
 
     #[test]
+    fn build_series_index_detects_duplicate_and_out_of_order_series() {
+        let duplicate_rows = vec![
+            thread_row(20, 1, "[PATCH v2 1/2] first", "a@example.com", 0),
+            thread_row(20, 2, "[PATCH v2 1/2] reroll", "b@example.com", 1),
+            thread_row(20, 3, "[PATCH v2 2/2] second", "c@example.com", 1),
+        ];
+        let duplicate_index = build_series_index("io-uring", &duplicate_rows);
+        let duplicate = duplicate_index.get(&20).expect("duplicate series exists");
+        assert_eq!(duplicate.integrity, SeriesIntegrity::Duplicate);
+        assert_eq!(duplicate.duplicate_seq, vec![1]);
+        assert_eq!(
+            duplicate.integrity_reason().as_deref(),
+            Some("duplicate patch index: 1")
+        );
+        assert_eq!(duplicate.integrity.short_label(), "duplicate");
+
+        let out_of_order_rows = vec![
+            thread_row(21, 1, "[PATCH v1 2/2] second", "p2@example.com", 0),
+            thread_row(21, 2, "[PATCH v1 1/2] first", "p1@example.com", 1),
+        ];
+        let out_of_order_index = build_series_index("io-uring", &out_of_order_rows);
+        let out_of_order = out_of_order_index
+            .get(&21)
+            .expect("out-of-order series exists");
+        assert_eq!(out_of_order.integrity, SeriesIntegrity::OutOfOrder);
+        assert!(out_of_order.out_of_order);
+        assert_eq!(
+            out_of_order.integrity_reason().as_deref(),
+            Some("patch order is out-of-order in thread")
+        );
+    }
+
+    #[test]
+    fn build_series_index_marks_cover_only_series_invalid() {
+        let rows = vec![thread_row(
+            22,
+            1,
+            "[PATCH v4 0/2] io_uring: cover letter only",
+            "cover@example.com",
+            0,
+        )];
+        let index = build_series_index("io-uring", &rows);
+        let series = index.get(&22).expect("series exists");
+        assert_eq!(series.integrity, SeriesIntegrity::Invalid);
+        assert!(series.items.is_empty());
+        assert_eq!(series.anchor_message_id, "cover@example.com");
+        assert_eq!(
+            series.integrity_reason().as_deref(),
+            Some("no valid [PATCH vN M/N] sequence found")
+        );
+    }
+
+    #[test]
     fn apply_requires_kernel_tree_configuration() {
         let runtime = runtime_with_kernel_trees(Vec::new());
         let error = action_working_dir(&runtime, PatchAction::Apply).expect_err("should fail");
         assert!(error.to_string().contains("[kernel].tree"));
+    }
+
+    #[test]
+    fn apply_requires_existing_kernel_tree_directory() {
+        let root = temp_dir("apply-missing-tree");
+        let missing = root.join("missing-tree");
+        let runtime = runtime_in(&root, vec![missing.clone()]);
+
+        let error = action_working_dir(&runtime, PatchAction::Apply).expect_err("missing tree");
+        assert!(error.to_string().contains("does not exist"));
+
+        let file_path = root.join("not-a-directory");
+        fs::write(&file_path, "file").expect("write file");
+        let runtime = runtime_in(&root, vec![file_path.clone()]);
+        let error = action_working_dir(&runtime, PatchAction::Apply).expect_err("file tree");
+        assert!(error.to_string().contains("is not"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -1385,6 +1681,187 @@ mod tests {
         let working_dir =
             action_working_dir(&runtime, PatchAction::Download).expect("download dir resolution");
         assert!(working_dir.is_none());
+    }
+
+    #[test]
+    fn run_action_download_records_reviewing_report() {
+        let root = temp_dir("run-action-download");
+        let b4_script = write_script(
+            &root,
+            "fake-b4.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 0.14.0'\n  exit 0\nfi\nif [ \"$1\" = \"am\" ]; then\n  echo 'downloaded patch series'\n  exit 0\nfi\nexit 1\n",
+        );
+        let mut runtime = runtime_in(&root, Vec::new());
+        runtime.b4_path = Some(b4_script);
+        initialize_patch_runtime(&runtime, &[(1, "patch@example.com")]);
+        let summary = sample_summary("io_uring: exported series", 2);
+
+        let result = run_action(&runtime, &summary, PatchAction::Download).expect("download runs");
+
+        assert_eq!(result.status, PatchSeriesStatus::Reviewing);
+        assert_eq!(result.exit_code, Some(0));
+        assert!(!result.timed_out);
+        assert!(result.command_line.contains("am"));
+        assert!(result.summary.starts_with("series downloaded to "));
+        let output_path = result.output_path.expect("download path");
+        assert!(output_path.starts_with(&runtime.patch_dir));
+        assert!(output_path.is_dir());
+
+        let latest = load_latest_report(&runtime.database_path, "io-uring", summary.thread_id)
+            .expect("load latest report")
+            .expect("report exists");
+        assert_eq!(latest.status, PatchSeriesStatus::Reviewing);
+        assert_eq!(latest.last_error, None);
+        assert_eq!(latest.last_exit_code, Some(0));
+        assert_eq!(
+            latest.last_summary.as_deref(),
+            Some(result.summary.as_str())
+        );
+        assert_eq!(
+            latest.last_command.as_deref(),
+            Some(result.command_line.as_str())
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_action_apply_marks_conflicts_in_latest_report() {
+        let root = temp_dir("run-action-conflict");
+        let repo = root.join("linux");
+        fs::create_dir_all(&repo).expect("create repo");
+        run_git(&repo, &["init"]);
+        run_git(&repo, &["config", "user.name", "CRIEW Test"]);
+        run_git(&repo, &["config", "user.email", "criew@example.com"]);
+        fs::write(repo.join("base.txt"), "base\n").expect("write base");
+        run_git(&repo, &["add", "base.txt"]);
+        run_git(&repo, &["commit", "-m", "base"]);
+
+        let b4_script = write_script(
+            &root,
+            "fake-b4.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 0.14.0'\n  exit 0\nfi\nif [ \"$1\" = \"shazam\" ]; then\n  echo 'patch failed at 0001 demo' >&2\n  exit 1\nfi\nexit 1\n",
+        );
+        let mut runtime = runtime_in(&root, vec![repo.clone()]);
+        runtime.b4_path = Some(b4_script);
+        initialize_patch_runtime(&runtime, &[(1, "patch@example.com")]);
+        let summary = sample_summary("io_uring: conflict series", 1);
+
+        let result = run_action(&runtime, &summary, PatchAction::Apply).expect("apply runs");
+
+        assert_eq!(result.status, PatchSeriesStatus::Conflict);
+        assert_eq!(result.exit_code, Some(1));
+        assert!(result.summary.contains("series apply conflict"));
+        assert!(result.head_before.is_none());
+        assert!(result.head_after.is_none());
+
+        let latest = load_latest_report(&runtime.database_path, "io-uring", summary.thread_id)
+            .expect("load latest report")
+            .expect("report exists");
+        assert_eq!(latest.status, PatchSeriesStatus::Conflict);
+        assert_eq!(latest.last_error.as_deref(), Some(result.summary.as_str()));
+        assert_eq!(
+            latest.last_summary.as_deref(),
+            Some(result.summary.as_str())
+        );
+        assert_eq!(latest.last_exit_code, Some(1));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_action_apply_rejects_noop_success_when_head_does_not_move() {
+        let root = temp_dir("run-action-noop");
+        let repo = root.join("linux");
+        fs::create_dir_all(&repo).expect("create repo");
+        run_git(&repo, &["init"]);
+        run_git(&repo, &["config", "user.name", "CRIEW Test"]);
+        run_git(&repo, &["config", "user.email", "criew@example.com"]);
+        fs::write(repo.join("base.txt"), "base\n").expect("write base");
+        run_git(&repo, &["add", "base.txt"]);
+        run_git(&repo, &["commit", "-m", "base"]);
+
+        let b4_script = write_script(
+            &root,
+            "fake-b4.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 0.14.0'\n  exit 0\nfi\nif [ \"$1\" = \"shazam\" ]; then\n  echo 'applied without commit'\n  exit 0\nfi\nexit 1\n",
+        );
+        let mut runtime = runtime_in(&root, vec![repo.clone()]);
+        runtime.b4_path = Some(b4_script);
+        initialize_patch_runtime(&runtime, &[(1, "patch@example.com")]);
+        let summary = sample_summary("io_uring: noop series", 1);
+
+        let result = run_action(&runtime, &summary, PatchAction::Apply).expect("apply runs");
+
+        assert_eq!(result.status, PatchSeriesStatus::Failed);
+        assert_eq!(result.exit_code, Some(0));
+        assert!(result.summary.contains("git HEAD did not move"));
+        assert!(result.head_before.is_none());
+        assert!(result.head_after.is_none());
+
+        let latest = load_latest_report(&runtime.database_path, "io-uring", summary.thread_id)
+            .expect("load latest report")
+            .expect("report exists");
+        assert_eq!(latest.status, PatchSeriesStatus::Failed);
+        assert_eq!(latest.last_error.as_deref(), Some(result.summary.as_str()));
+        assert_eq!(
+            latest.last_summary.as_deref(),
+            Some(result.summary.as_str())
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_action_apply_records_head_change_and_moves_artifacts() {
+        let root = temp_dir("run-action-apply-success");
+        let repo = root.join("linux");
+        fs::create_dir_all(&repo).expect("create repo");
+        run_git(&repo, &["init"]);
+        run_git(&repo, &["config", "user.name", "CRIEW Test"]);
+        run_git(&repo, &["config", "user.email", "criew@example.com"]);
+        fs::write(repo.join("base.txt"), "base\n").expect("write base");
+        run_git(&repo, &["add", "base.txt"]);
+        run_git(&repo, &["commit", "-m", "base"]);
+
+        let b4_script = write_script(
+            &root,
+            "fake-b4.sh",
+            "#!/bin/sh\nset -e\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 0.14.0'\n  exit 0\nfi\nif [ \"$1\" = \"shazam\" ]; then\n  printf 'applied by fake b4\\n' > applied.txt\n  git add applied.txt\n  git commit -m 'apply-series' >/dev/null 2>&1\n  printf 'mbx\\n' > demo-series.mbx\n  printf 'cover\\n' > demo-series.cover\n  exit 0\nfi\nexit 1\n",
+        );
+        let mut runtime = runtime_in(&root, vec![repo.clone()]);
+        runtime.b4_path = Some(b4_script);
+        initialize_patch_runtime(&runtime, &[(1, "patch@example.com")]);
+        let summary = sample_summary("io_uring: applied series", 1);
+
+        let result = run_action(&runtime, &summary, PatchAction::Apply).expect("apply runs");
+
+        assert_eq!(result.status, PatchSeriesStatus::Applied);
+        assert_eq!(result.exit_code, Some(0));
+        assert!(result.summary.contains("series applied by b4 shazam"));
+        assert!(result.summary.contains("artifacts moved to"));
+        let head_before = result.head_before.expect("head before");
+        let head_after = result.head_after.expect("head after");
+        assert_ne!(head_before, head_after);
+
+        let output_path = result.output_path.expect("artifact path");
+        assert!(output_path.starts_with(runtime.patch_dir.join(APPLY_ARTIFACTS_DIR)));
+        assert!(output_path.join("demo-series.mbx").exists());
+        assert!(output_path.join("demo-series.cover").exists());
+        assert!(!repo.join("demo-series.mbx").exists());
+        assert!(!repo.join("demo-series.cover").exists());
+
+        let latest = load_latest_report(&runtime.database_path, "io-uring", summary.thread_id)
+            .expect("load latest report")
+            .expect("report exists");
+        assert_eq!(latest.status, PatchSeriesStatus::Applied);
+        assert_eq!(latest.last_error, None);
+        assert_eq!(
+            latest.last_summary.as_deref(),
+            Some(result.summary.as_str())
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/infra/b4.rs
+++ b/src/infra/b4.rs
@@ -13,6 +13,9 @@ use std::time::{Duration, Instant};
 use super::b4_vendor;
 use crate::infra::error::{CriewError, ErrorCode, Result};
 
+const EXECUTABLE_BUSY_RETRY_ATTEMPTS: u8 = 5;
+const EXECUTABLE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+
 #[derive(Debug, Clone)]
 pub struct B4Check {
     pub status: B4Status,
@@ -47,7 +50,10 @@ struct ResolvedCommand {
 }
 
 pub fn check(configured_path: Option<&Path>, runtime_data_dir: Option<&Path>) -> B4Check {
-    let candidates = candidates(configured_path, runtime_data_dir);
+    check_from_candidates(candidates(configured_path, runtime_data_dir))
+}
+
+fn check_from_candidates(candidates: Vec<Candidate>) -> B4Check {
     let mut last_failure: Option<(PathBuf, String)> = None;
 
     for candidate in candidates {
@@ -84,7 +90,16 @@ pub fn run(
     working_dir: Option<&Path>,
 ) -> Result<B4CommandResult> {
     let resolved = resolve_command(configured_path, runtime_data_dir)?;
+    run_with_resolved_command(&resolved, subcommand, args, timeout, working_dir)
+}
 
+fn run_with_resolved_command(
+    resolved: &ResolvedCommand,
+    subcommand: &str,
+    args: &[String],
+    timeout: Duration,
+    working_dir: Option<&Path>,
+) -> Result<B4CommandResult> {
     let mut command = Command::new(&resolved.command);
     if let Some(working_dir) = working_dir {
         command.current_dir(working_dir);
@@ -96,7 +111,7 @@ pub fn run(
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let command_line = render_command_line(&resolved.command, subcommand, args);
-    let mut child = command.spawn().map_err(|error| {
+    let mut child = spawn_command_with_retry(&mut command).map_err(|error| {
         CriewError::with_source(
             ErrorCode::B4,
             format!(
@@ -152,6 +167,22 @@ pub fn run(
 }
 
 fn candidates(configured_path: Option<&Path>, runtime_data_dir: Option<&Path>) -> Vec<Candidate> {
+    let env_b4_path = env::var_os("CRIEW_B4_PATH").map(PathBuf::from);
+    let cwd = env::current_dir().ok();
+    candidates_with(
+        configured_path,
+        runtime_data_dir,
+        env_b4_path.as_deref(),
+        cwd.as_deref(),
+    )
+}
+
+fn candidates_with(
+    configured_path: Option<&Path>,
+    runtime_data_dir: Option<&Path>,
+    env_b4_path: Option<&Path>,
+    cwd: Option<&Path>,
+) -> Vec<Candidate> {
     let mut values = Vec::new();
 
     // Discovery order is from most explicit to most implicit so user config
@@ -160,14 +191,13 @@ fn candidates(configured_path: Option<&Path>, runtime_data_dir: Option<&Path>) -
         values.push(Candidate::Path(path.to_path_buf()));
     }
 
-    if let Ok(env_path) = env::var("CRIEW_B4_PATH") {
-        let path = PathBuf::from(env_path);
+    if let Some(path) = env_b4_path {
         if !path.as_os_str().is_empty() {
-            values.push(Candidate::Path(path));
+            values.push(Candidate::Path(path.to_path_buf()));
         }
     }
 
-    if let Ok(cwd) = env::current_dir() {
+    if let Some(cwd) = cwd {
         values.push(Candidate::Path(cwd.join("vendor/b4/b4.sh")));
     }
 
@@ -219,11 +249,26 @@ fn probe(candidate: &Candidate) -> Probe {
     }
 }
 
+fn spawn_command_with_retry(command: &mut Command) -> std::io::Result<std::process::Child> {
+    let mut attempts_remaining = EXECUTABLE_BUSY_RETRY_ATTEMPTS;
+
+    loop {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if is_retryable_executable_busy(&error) && attempts_remaining > 0 => {
+                attempts_remaining -= 1;
+                thread::sleep(EXECUTABLE_BUSY_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 fn run_probe<T>(command: T, label: &Path, command_value: String) -> Probe
 where
     T: AsRef<std::ffi::OsStr>,
 {
-    match Command::new(command).arg("--version").output() {
+    match output_with_retry(Command::new(command).arg("--version")) {
         Ok(output) if output.status.success() => {
             let version = normalize_output(&output.stdout)
                 .or_else(|| normalize_output(&output.stderr))
@@ -253,12 +298,35 @@ where
     }
 }
 
+fn output_with_retry(command: &mut Command) -> std::io::Result<std::process::Output> {
+    let mut attempts_remaining = EXECUTABLE_BUSY_RETRY_ATTEMPTS;
+
+    loop {
+        match command.output() {
+            Ok(output) => return Ok(output),
+            Err(error) if is_retryable_executable_busy(&error) && attempts_remaining > 0 => {
+                attempts_remaining -= 1;
+                thread::sleep(EXECUTABLE_BUSY_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_retryable_executable_busy(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::ExecutableFileBusy
+}
+
 fn resolve_command(
     configured_path: Option<&Path>,
     runtime_data_dir: Option<&Path>,
 ) -> Result<ResolvedCommand> {
+    resolve_from_candidates(candidates(configured_path, runtime_data_dir))
+}
+
+fn resolve_from_candidates(candidates: Vec<Candidate>) -> Result<ResolvedCommand> {
     let mut last_failure: Option<(PathBuf, String)> = None;
-    for candidate in candidates(configured_path, runtime_data_dir) {
+    for candidate in candidates {
         match probe(&candidate) {
             Probe::Available { command, path, .. } => {
                 return Ok(ResolvedCommand {
@@ -317,4 +385,249 @@ fn normalize_output(bytes: &[u8]) -> Option<String> {
         .map(str::trim)
         .find(|line| !line.is_empty())
         .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use crate::infra::error::ErrorCode;
+
+    use super::{
+        B4Status, Candidate, Probe, candidates_with, check_from_candidates, normalize_output,
+        probe, render_command_line, resolve_from_candidates, run_with_resolved_command,
+    };
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("criew-b4-{label}-{nonce}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn write_script(root: &Path, name: &str, body: &str) -> PathBuf {
+        let path = root.join(name);
+        let staging_path = root.join(format!(".{name}.tmp"));
+        let mut staging_file = fs::File::create(&staging_path).expect("create staging script");
+        staging_file
+            .write_all(body.as_bytes())
+            .expect("write staging script");
+        staging_file.sync_all().expect("sync staging script");
+        drop(staging_file);
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&staging_path)
+                .expect("staging metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&staging_path, permissions).expect("mark executable");
+        }
+        fs::rename(&staging_path, &path).expect("install script");
+        path
+    }
+
+    #[test]
+    fn check_prefers_available_configured_script() {
+        let root = temp_dir("configured-ok");
+        let configured_script = write_script(
+            &root,
+            "b4-ok.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 1.2.3'\n  exit 0\nfi\nexit 0\n",
+        );
+        let fallback_script = write_script(
+            &root,
+            "b4-fallback.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 9.9.9'\n  exit 0\nfi\nexit 0\n",
+        );
+
+        let result = check_from_candidates(vec![
+            Candidate::Path(configured_script.clone()),
+            Candidate::Path(fallback_script),
+        ]);
+
+        match result.status {
+            B4Status::Available { path, version } => {
+                assert_eq!(path, configured_script);
+                assert_eq!(version, "b4 1.2.3");
+            }
+            status => panic!("expected available status, got {status:?}"),
+        }
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn check_reports_broken_configured_script_when_no_fallback_exists() {
+        let root = temp_dir("configured-broken");
+        let script = write_script(
+            &root,
+            "b4-broken.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'broken runtime' >&2\n  exit 1\nfi\nexit 1\n",
+        );
+
+        let result = check_from_candidates(vec![Candidate::Path(script.clone())]);
+
+        match result.status {
+            B4Status::Broken { path, reason } => {
+                assert_eq!(path, script);
+                assert_eq!(reason, "broken runtime");
+            }
+            status => panic!("expected broken status, got {status:?}"),
+        }
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_executes_configured_script_in_requested_workdir() {
+        let root = temp_dir("run-ok");
+        let workdir = root.join("workdir");
+        fs::create_dir_all(&workdir).expect("create workdir");
+        let script = write_script(
+            &root,
+            "b4-run.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 2.0.0'\n  exit 0\nfi\nprintf 'cwd=%s\\n' \"$PWD\"\nprintf 'subcommand=%s\\n' \"$1\"\nprintf 'arg1=%s\\n' \"$2\"\nprintf 'arg2=%s\\n' \"$3\"\nprintf 'stderr-line\\n' >&2\n",
+        );
+
+        let resolved = resolve_from_candidates(vec![Candidate::Path(script.clone())])
+            .expect("resolve configured b4");
+        let result = run_with_resolved_command(
+            &resolved,
+            "am",
+            &["--foo".to_string(), "bar baz".to_string()],
+            Duration::from_secs(1),
+            Some(&workdir),
+        )
+        .expect("run b4");
+
+        assert_eq!(result.exit_code, Some(0));
+        assert!(!result.timed_out);
+        assert_eq!(
+            result.command_line,
+            format!("{} am --foo 'bar baz'", script.display())
+        );
+        assert!(
+            result
+                .stdout
+                .contains(&format!("cwd={}", workdir.display()))
+        );
+        assert!(result.stdout.contains("subcommand=am"));
+        assert!(result.stdout.contains("arg1=--foo"));
+        assert!(result.stdout.contains("arg2=bar baz"));
+        assert!(result.stderr.contains("stderr-line"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_marks_timed_out_processes() {
+        let root = temp_dir("run-timeout");
+        let script = write_script(
+            &root,
+            "b4-timeout.sh",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'b4 2.1.0'\n  exit 0\nfi\nwhile :; do :; done\n",
+        );
+
+        let resolved =
+            resolve_from_candidates(vec![Candidate::Path(script)]).expect("resolve timeout b4");
+        let result =
+            run_with_resolved_command(&resolved, "am", &[], Duration::from_millis(10), None)
+                .expect("run b4");
+
+        assert!(result.timed_out);
+        assert_ne!(result.exit_code, Some(0));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn candidates_include_config_env_cwd_runtime_and_program_in_order() {
+        let root = temp_dir("candidates");
+        let cwd = root.join("cwd");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let configured = root.join("configured-b4");
+        let env_path = root.join("env-b4");
+        let runtime = root.join("runtime");
+
+        let values = candidates_with(
+            Some(&configured),
+            Some(&runtime),
+            Some(&env_path),
+            Some(&cwd),
+        );
+
+        assert!(matches!(&values[0], Candidate::Path(path) if path == &configured));
+        assert!(matches!(&values[1], Candidate::Path(path) if path == &env_path));
+        assert!(
+            matches!(&values[2], Candidate::Path(path) if path == &cwd.join("vendor/b4/b4.sh"))
+        );
+        assert!(matches!(&values[3], Candidate::EmbeddedVendor(path) if path == &runtime));
+        assert!(matches!(&values[4], Candidate::Program(program) if program == "b4"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn probe_reports_missing_and_embedded_vendor_failures() {
+        let missing = probe(&Candidate::Path(PathBuf::from("/definitely/missing/b4")));
+        assert!(matches!(missing, Probe::Missing));
+
+        let root = temp_dir("embedded-broken");
+        let vendor_root = root.join("vendor");
+        fs::write(&vendor_root, "not a directory").expect("block vendor root");
+
+        let broken = probe(&Candidate::EmbeddedVendor(root.clone()));
+        match broken {
+            Probe::Broken { path, reason } => {
+                assert_eq!(path, root.join("vendor/b4/b4.sh"));
+                assert!(reason.contains("failed to create embedded b4 directory"));
+            }
+            _ => panic!("expected broken embedded vendor probe"),
+        }
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_command_reports_not_found_without_candidates() {
+        let error = resolve_from_candidates(vec![
+            Candidate::Path(PathBuf::from("/definitely/missing/b4")),
+            Candidate::Program("criew-b4-definitely-missing".to_string()),
+        ])
+        .expect_err("missing b4 should fail");
+
+        assert_eq!(error.code(), ErrorCode::B4);
+        assert!(error.to_string().contains("b4 executable not found"));
+    }
+
+    #[test]
+    fn render_command_line_quotes_special_tokens() {
+        let rendered = render_command_line(
+            "/tmp/demo path/b4.sh",
+            "am",
+            &["bar baz".to_string(), "quote'char".to_string()],
+        );
+
+        assert_eq!(
+            rendered,
+            "'/tmp/demo path/b4.sh' am 'bar baz' 'quote'\\''char'"
+        );
+    }
+
+    #[test]
+    fn normalize_output_returns_first_non_empty_trimmed_line() {
+        assert_eq!(
+            normalize_output(b"\n  \n  b4 3.0.0  \nnext line\n"),
+            Some("b4 3.0.0".to_string())
+        );
+        assert_eq!(normalize_output(b"\n\t \n"), None);
+    }
 }

--- a/src/infra/b4_vendor.rs
+++ b/src/infra/b4_vendor.rs
@@ -131,4 +131,51 @@ mod tests {
 
         let _ = fs::remove_dir_all(&temp_root);
     }
+
+    #[test]
+    fn ensure_installed_is_idempotent_for_existing_runtime_tree() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!(
+            "criew-b4-vendor-repeat-test-{}-{nonce}",
+            std::process::id()
+        ));
+
+        let first = ensure_installed(&temp_root).expect("first embedded b4 install");
+        let second = ensure_installed(&temp_root).expect("second embedded b4 install");
+
+        assert_eq!(first, second);
+        if let Some(script) = second {
+            assert_eq!(script, script_path(&temp_root));
+            assert!(script.exists(), "embedded b4 script should still exist");
+        }
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn ensure_installed_reports_directory_conflicts() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!(
+            "criew-b4-vendor-conflict-test-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        fs::write(temp_root.join("vendor"), "not a directory").expect("write blocking vendor file");
+
+        let error = ensure_installed(&temp_root).expect_err("conflicting vendor path should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to create embedded b4 directory")
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
 }

--- a/src/infra/bootstrap.rs
+++ b/src/infra/bootstrap.rs
@@ -106,3 +106,98 @@ fn ensure_runtime_dirs(config: &RuntimeConfig) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::infra::config::{DEFAULT_INBOX_AUTO_SYNC_INTERVAL_SECS, ImapConfig, UiKeymap};
+    use crate::infra::db::CURRENT_SCHEMA_VERSION;
+    use crate::infra::error::ErrorCode;
+
+    use super::{RuntimeConfig, prepare};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("criew-bootstrap-{label}-{nonce}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn test_runtime_in(root: PathBuf) -> RuntimeConfig {
+        RuntimeConfig {
+            config_path: root.join("config").join("criew-config.toml"),
+            data_dir: root.join("data"),
+            database_path: root.join("data").join("db").join("criew.db"),
+            raw_mail_dir: root.join("data").join("raw"),
+            patch_dir: root.join("data").join("patches"),
+            log_dir: root.join("logs"),
+            b4_path: None,
+            log_filter: "info".to_string(),
+            source_mailbox: "linux-kernel".to_string(),
+            imap: ImapConfig::default(),
+            lore_base_url: "https://lore.kernel.org".to_string(),
+            startup_sync: true,
+            ui_keymap: UiKeymap::Default,
+            inbox_auto_sync_interval_secs: DEFAULT_INBOX_AUTO_SYNC_INTERVAL_SECS,
+            kernel_trees: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn prepare_creates_runtime_state_and_is_idempotent() {
+        let root = temp_dir("prepare");
+        let runtime = test_runtime_in(root.clone());
+
+        let first = prepare(&runtime).expect("prepare runtime");
+        let second = prepare(&runtime).expect("prepare existing runtime");
+
+        assert!(runtime.config_path.parent().expect("config dir").is_dir());
+        assert!(runtime.data_dir.is_dir());
+        assert!(runtime.raw_mail_dir.is_dir());
+        assert!(runtime.patch_dir.is_dir());
+        assert!(runtime.log_dir.is_dir());
+        assert!(runtime.database_path.is_file());
+
+        assert_eq!(first.db.path, runtime.database_path);
+        assert!(first.db.created);
+        assert_eq!(first.db.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(
+            first.db.applied_migrations,
+            vec![1, 2, 3, CURRENT_SCHEMA_VERSION]
+        );
+
+        assert_eq!(second.db.path, runtime.database_path);
+        assert!(!second.db.created);
+        assert_eq!(second.db.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(second.db.applied_migrations.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prepare_reports_runtime_directory_conflicts() {
+        let root = temp_dir("prepare-conflict");
+        let blocked_path = root.join("blocked");
+        fs::write(&blocked_path, "not a directory").expect("write blocking file");
+
+        let mut runtime = test_runtime_in(root.clone());
+        runtime.data_dir = blocked_path.join("data");
+
+        let error = prepare(&runtime).expect_err("conflicting data directory should fail");
+
+        assert_eq!(error.code(), ErrorCode::Io);
+        assert!(
+            error
+                .to_string()
+                .contains("failed to create data directory")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/infra/db.rs
+++ b/src/infra/db.rs
@@ -165,6 +165,8 @@ mod tests {
 
     use rusqlite::Connection;
 
+    use crate::infra::error::ErrorCode;
+
     use super::{CURRENT_SCHEMA_VERSION, initialize};
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -197,6 +199,123 @@ mod tests {
             })
             .expect("query version");
         assert_eq!(version, CURRENT_SCHEMA_VERSION);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn initialize_is_idempotent_for_existing_database() {
+        let root = temp_dir("db-reinitialize");
+        let db_path = root.join("criew.db");
+
+        let first = initialize(&db_path).expect("initialize db");
+        let second = initialize(&db_path).expect("reinitialize db");
+
+        assert!(first.created);
+        assert_eq!(second.path, db_path);
+        assert!(!second.created);
+        assert_eq!(second.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(second.applied_migrations.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn initialize_reports_missing_parent_directory() {
+        let root = temp_dir("db-missing-parent");
+        let db_path = root.join("missing").join("criew.db");
+
+        let error = initialize(&db_path).expect_err("missing parent directory should fail");
+
+        assert_eq!(error.code(), ErrorCode::Database);
+        assert!(error.to_string().contains("failed to open sqlite database"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn initialize_reports_schema_version_table_creation_conflicts() {
+        let root = temp_dir("db-schema-version-conflict");
+        let db_path = root.join("criew.db");
+        let connection = Connection::open(&db_path).expect("open sqlite");
+        connection
+            .execute("CREATE VIEW schema_version AS SELECT 1 AS version", [])
+            .expect("create conflicting view");
+        drop(connection);
+
+        let error = initialize(&db_path).expect_err("schema_version conflict should fail");
+
+        assert_eq!(error.code(), ErrorCode::Database);
+        assert!(error.to_string().contains("schema") || error.to_string().contains("migration"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn initialize_reports_schema_version_query_failure_for_invalid_table_shape() {
+        let root = temp_dir("db-schema-version-shape");
+        let db_path = root.join("criew.db");
+        let connection = Connection::open(&db_path).expect("open sqlite");
+        connection
+            .execute(
+                "CREATE TABLE schema_version (description TEXT NOT NULL)",
+                [],
+            )
+            .expect("create malformed schema_version");
+        drop(connection);
+
+        let error = initialize(&db_path).expect_err("invalid schema_version shape should fail");
+
+        assert_eq!(error.code(), ErrorCode::Database);
+        assert!(error.to_string().contains("failed to query schema version"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn initialize_reports_migration_and_registration_failures() {
+        let root = temp_dir("db-migration-failures");
+
+        let conflicting_db_path = root.join("migration-sql.db");
+        let connection = Connection::open(&conflicting_db_path).expect("open conflicting sqlite");
+        connection
+            .execute(
+                "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, description TEXT NOT NULL, applied_at TEXT NOT NULL DEFAULT '')",
+                [],
+            )
+            .expect("create schema_version");
+        connection
+            .execute("CREATE VIEW mail AS SELECT 1 AS id", [])
+            .expect("create conflicting mail view");
+        drop(connection);
+
+        let migration_error =
+            initialize(&conflicting_db_path).expect_err("migration SQL conflict should fail");
+        assert_eq!(migration_error.code(), ErrorCode::Database);
+        assert!(
+            migration_error
+                .to_string()
+                .contains("failed to run migration 1")
+        );
+
+        let missing_column_db_path = root.join("migration-register.db");
+        let connection = Connection::open(&missing_column_db_path).expect("open sqlite");
+        connection
+            .execute(
+                "CREATE TABLE schema_version (version INTEGER PRIMARY KEY)",
+                [],
+            )
+            .expect("create truncated schema_version");
+        drop(connection);
+
+        let register_error =
+            initialize(&missing_column_db_path).expect_err("migration registration should fail");
+        assert_eq!(register_error.code(), ErrorCode::Database);
+        assert!(
+            register_error
+                .to_string()
+                .contains("failed to register migration 1")
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/infra/imap.rs
+++ b/src/infra/imap.rs
@@ -31,6 +31,12 @@ const IMAP_FETCH_BATCH_SIZE: usize = 100;
 const GNU_ARCHIVE_INITIAL_MONTH_LIMIT: usize = 2;
 const GNU_ARCHIVE_UID_STRIDE: u32 = 1_000_000;
 
+#[cfg(test)]
+trait TestTransportIo: Read + Write + Send {}
+
+#[cfg(test)]
+impl<T> TestTransportIo for T where T: Read + Write + Send {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum ImapErrorKind {
@@ -371,7 +377,7 @@ impl LoreImapClient {
             )
         })?;
 
-        let status = response.status();
+        let status_code = response.status().as_u16();
         let body = response.text().map_err(|error| {
             CriewError::with_source(
                 ErrorCode::Imap,
@@ -380,43 +386,19 @@ impl LoreImapClient {
             )
         })?;
 
-        if !status.is_success() {
-            return Err(imap_error(
-                ImapErrorKind::MailboxSelection,
-                format!("failed to fetch lore feed {url}: HTTP {status}"),
-            ));
-        }
-
-        parse_lore_atom_entries(&body)
+        parse_lore_feed_response(&url, status_code, &body)
     }
 
     fn fetch_raw_mail(&self, message_url: &str) -> Result<Vec<u8>> {
-        let mut last_error: Option<CriewError> = None;
-
-        for raw_url in lore_raw_url_candidates(message_url) {
-            let response = match self.client.get(&raw_url).send() {
-                Ok(response) => response,
-                Err(error) => {
-                    last_error = Some(CriewError::with_source(
-                        ErrorCode::Imap,
-                        format!("failed to fetch lore raw message {raw_url}"),
-                        error,
-                    ));
-                    continue;
-                }
-            };
-
-            if !response.status().is_success() {
-                last_error = Some(imap_error(
-                    ImapErrorKind::Protocol,
-                    format!(
-                        "failed to fetch lore raw message {raw_url}: HTTP {}",
-                        response.status()
-                    ),
-                ));
-                continue;
-            }
-
+        fetch_lore_raw_with(message_url, |raw_url| {
+            let response = self.client.get(raw_url).send().map_err(|error| {
+                CriewError::with_source(
+                    ErrorCode::Imap,
+                    format!("failed to fetch lore raw message {raw_url}"),
+                    error,
+                )
+            })?;
+            let status_code = response.status().as_u16();
             let bytes = response.bytes().map_err(|error| {
                 CriewError::with_source(
                     ErrorCode::Imap,
@@ -424,24 +406,88 @@ impl LoreImapClient {
                     error,
                 )
             })?;
+            Ok((status_code, bytes.to_vec()))
+        })
+    }
+}
 
-            if !bytes.is_empty() {
-                return Ok(bytes.to_vec());
+fn parse_lore_feed_response(url: &str, status_code: u16, body: &str) -> Result<Vec<LoreFeedEntry>> {
+    if !(200..300).contains(&status_code) {
+        return Err(imap_error(
+            ImapErrorKind::MailboxSelection,
+            format!("failed to fetch lore feed {url}: HTTP {status_code}"),
+        ));
+    }
+
+    parse_lore_atom_entries(body)
+}
+
+fn fetch_lore_raw_with<F>(message_url: &str, mut fetch_response: F) -> Result<Vec<u8>>
+where
+    F: FnMut(&str) -> Result<(u16, Vec<u8>)>,
+{
+    let mut last_error: Option<CriewError> = None;
+
+    for raw_url in lore_raw_url_candidates(message_url) {
+        let (status_code, bytes) = match fetch_response(&raw_url) {
+            Ok(response) => response,
+            Err(error) => {
+                last_error = Some(error);
+                continue;
             }
+        };
 
+        if !(200..300).contains(&status_code) {
             last_error = Some(imap_error(
                 ImapErrorKind::Protocol,
-                format!("lore raw message is empty: {raw_url}"),
+                format!("failed to fetch lore raw message {raw_url}: HTTP {status_code}"),
             ));
+            continue;
         }
 
-        Err(last_error.unwrap_or_else(|| {
-            imap_error(
-                ImapErrorKind::Protocol,
-                format!("failed to resolve raw message URL for {message_url}"),
-            )
-        }))
+        if !bytes.is_empty() {
+            return Ok(bytes);
+        }
+
+        last_error = Some(imap_error(
+            ImapErrorKind::Protocol,
+            format!("lore raw message is empty: {raw_url}"),
+        ));
     }
+
+    Err(last_error.unwrap_or_else(|| {
+        imap_error(
+            ImapErrorKind::Protocol,
+            format!("failed to resolve raw message URL for {message_url}"),
+        )
+    }))
+}
+
+fn build_lore_incremental_mails<F>(
+    entries: Vec<LoreFeedEntry>,
+    since_modseq: Option<u64>,
+    mut fetch_raw_mail: F,
+) -> Result<Vec<RemoteMail>>
+where
+    F: FnMut(&str) -> Result<Vec<u8>>,
+{
+    let mut fetched = Vec::new();
+    for entry in entries {
+        if since_modseq.is_some_and(|checkpoint| entry.modseq <= checkpoint) {
+            continue;
+        }
+
+        let raw = fetch_raw_mail(&entry.message_url)?;
+        fetched.push(RemoteMail {
+            uid: 0,
+            modseq: Some(entry.modseq),
+            flags: Vec::new(),
+            raw,
+        });
+    }
+
+    fetched.sort_by_key(|mail| mail.modseq.unwrap_or(0));
+    Ok(fetched)
 }
 
 impl ImapClient for LoreImapClient {
@@ -470,24 +516,9 @@ impl ImapClient for LoreImapClient {
     ) -> Result<Vec<RemoteMail>> {
         self.ensure_connected()?;
         let entries = self.fetch_feed_entries(mailbox)?;
-
-        let mut fetched = Vec::new();
-        for entry in entries {
-            if since_modseq.is_some_and(|checkpoint| entry.modseq <= checkpoint) {
-                continue;
-            }
-
-            let raw = self.fetch_raw_mail(&entry.message_url)?;
-            fetched.push(RemoteMail {
-                uid: 0,
-                modseq: Some(entry.modseq),
-                flags: Vec::new(),
-                raw,
-            });
-        }
-
-        fetched.sort_by_key(|mail| mail.modseq.unwrap_or(0));
-        Ok(fetched)
+        build_lore_incremental_mails(entries, since_modseq, |message_url| {
+            self.fetch_raw_mail(message_url)
+        })
     }
 }
 
@@ -553,7 +584,7 @@ impl GnuArchiveClient {
             )
         })?;
 
-        let status = response.status();
+        let status_code = response.status().as_u16();
         let body = response.text().map_err(|error| {
             CriewError::with_source(
                 ErrorCode::Imap,
@@ -562,14 +593,7 @@ impl GnuArchiveClient {
             )
         })?;
 
-        if !status.is_success() {
-            return Err(imap_error(
-                ImapErrorKind::MailboxSelection,
-                format!("failed to fetch GNU archive index {url}: HTTP {status}"),
-            ));
-        }
-
-        parse_gnu_archive_month_entries(&body)
+        parse_gnu_archive_index_response(&url, status_code, &body)
     }
 
     fn fetch_month_mbox(&self, mailbox: &str, month_key: &str) -> Result<Vec<u8>> {
@@ -582,15 +606,8 @@ impl GnuArchiveClient {
             )
         })?;
 
-        let status = response.status();
-        if !status.is_success() {
-            return Err(imap_error(
-                ImapErrorKind::Protocol,
-                format!("failed to fetch GNU archive mbox {url}: HTTP {status}"),
-            ));
-        }
-
-        response
+        let status_code = response.status().as_u16();
+        let bytes = response
             .bytes()
             .map(|bytes| bytes.to_vec())
             .map_err(|error| {
@@ -599,8 +616,74 @@ impl GnuArchiveClient {
                     format!("failed to read GNU archive mbox body {url}"),
                     error,
                 )
-            })
+            })?;
+
+        validate_gnu_archive_mbox_response(&url, status_code, bytes)
     }
+}
+
+fn parse_gnu_archive_index_response(
+    url: &str,
+    status_code: u16,
+    body: &str,
+) -> Result<Vec<GnuArchiveMonthEntry>> {
+    if !(200..300).contains(&status_code) {
+        return Err(imap_error(
+            ImapErrorKind::MailboxSelection,
+            format!("failed to fetch GNU archive index {url}: HTTP {status_code}"),
+        ));
+    }
+
+    parse_gnu_archive_month_entries(body)
+}
+
+fn validate_gnu_archive_mbox_response(
+    url: &str,
+    status_code: u16,
+    body: Vec<u8>,
+) -> Result<Vec<u8>> {
+    if !(200..300).contains(&status_code) {
+        return Err(imap_error(
+            ImapErrorKind::Protocol,
+            format!("failed to fetch GNU archive mbox {url}: HTTP {status_code}"),
+        ));
+    }
+
+    Ok(body)
+}
+
+fn build_gnu_archive_incremental_mails<F>(
+    months: &[GnuArchiveMonthEntry],
+    since_modseq: Option<u64>,
+    mut fetch_month_mbox: F,
+) -> Result<Vec<RemoteMail>>
+where
+    F: FnMut(&str) -> Result<Vec<u8>>,
+{
+    let selected_months = select_gnu_archive_months(months, since_modseq);
+
+    let mut fetched = Vec::new();
+    for month in selected_months {
+        let raw_mbox = fetch_month_mbox(&month.month_key)?;
+        for (index, raw) in parse_gnu_archive_mbox_messages(&raw_mbox)
+            .into_iter()
+            .enumerate()
+        {
+            fetched.push(RemoteMail {
+                uid: gnu_archive_message_uid(&month.month_key, index),
+                modseq: Some(month.modseq),
+                flags: Vec::new(),
+                raw,
+            });
+        }
+    }
+
+    fetched.sort_by(|left, right| {
+        left.modseq
+            .cmp(&right.modseq)
+            .then_with(|| left.uid.cmp(&right.uid))
+    });
+    Ok(fetched)
 }
 
 impl ImapClient for GnuArchiveClient {
@@ -629,30 +712,9 @@ impl ImapClient for GnuArchiveClient {
     ) -> Result<Vec<RemoteMail>> {
         self.ensure_connected()?;
         let months = self.fetch_month_entries(mailbox)?;
-        let selected_months = select_gnu_archive_months(&months, since_modseq);
-
-        let mut fetched = Vec::new();
-        for month in selected_months {
-            let raw_mbox = self.fetch_month_mbox(mailbox, &month.month_key)?;
-            for (index, raw) in parse_gnu_archive_mbox_messages(&raw_mbox)
-                .into_iter()
-                .enumerate()
-            {
-                fetched.push(RemoteMail {
-                    uid: gnu_archive_message_uid(&month.month_key, index),
-                    modseq: Some(month.modseq),
-                    flags: Vec::new(),
-                    raw,
-                });
-            }
-        }
-
-        fetched.sort_by(|left, right| {
-            left.modseq
-                .cmp(&right.modseq)
-                .then_with(|| left.uid.cmp(&right.uid))
-        });
-        Ok(fetched)
+        build_gnu_archive_incremental_mails(&months, since_modseq, |month_key| {
+            self.fetch_month_mbox(mailbox, month_key)
+        })
     }
 }
 
@@ -760,6 +822,8 @@ fn collect_incremental_uids(
 enum ImapTransport {
     Plain(TcpStream),
     Tls(Box<StreamOwned<ClientConnection, TcpStream>>),
+    #[cfg(test)]
+    Mock(Box<dyn TestTransportIo>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -795,6 +859,8 @@ impl Read for ImapTransport {
         match self {
             Self::Plain(stream) => stream.read(buf),
             Self::Tls(stream) => stream.read(buf),
+            #[cfg(test)]
+            Self::Mock(stream) => stream.read(buf),
         }
     }
 }
@@ -804,6 +870,8 @@ impl Write for ImapTransport {
         match self {
             Self::Plain(stream) => stream.write(buf),
             Self::Tls(stream) => stream.write(buf),
+            #[cfg(test)]
+            Self::Mock(stream) => stream.write(buf),
         }
     }
 
@@ -811,6 +879,8 @@ impl Write for ImapTransport {
         match self {
             Self::Plain(stream) => stream.flush(),
             Self::Tls(stream) => stream.flush(),
+            #[cfg(test)]
+            Self::Mock(stream) => stream.flush(),
         }
     }
 }
@@ -829,6 +899,16 @@ enum GreetingKind {
 }
 
 impl ImapSession {
+    #[cfg(test)]
+    fn with_mock_stream(stream: impl TestTransportIo + 'static) -> Self {
+        Self {
+            transport: ImapTransport::Mock(Box::new(stream)),
+            read_buffer: Vec::new(),
+            next_tag: 1,
+            capabilities: HashSet::new(),
+        }
+    }
+
     fn connect(config: &ImapConfig) -> Result<Self> {
         let server = config.server.as_deref().ok_or_else(|| {
             imap_error(
@@ -873,6 +953,13 @@ impl ImapSession {
                     return Err(imap_error(
                         ImapErrorKind::Connection,
                         "STARTTLS attempted on TLS transport",
+                    ));
+                }
+                #[cfg(test)]
+                ImapTransport::Mock(_) => {
+                    return Err(imap_error(
+                        ImapErrorKind::Connection,
+                        "STARTTLS attempted on mock transport",
                     ));
                 }
             };
@@ -2157,8 +2244,10 @@ fn classify(kind: ImapErrorKind) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs;
     use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::path::PathBuf;
     use std::thread;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -2166,13 +2255,18 @@ mod tests {
     use crate::infra::config::{ImapConfig, ImapEncryption};
 
     use super::{
-        FixtureImapClient, GnuArchiveMonthEntry, ImapClient, ImapErrorKind, RemoteImapClient,
-        ensure_tagged_ok, establish_http_connect_tunnel, establish_socks5_tunnel,
-        format_uid_sequence_set, gnu_archive_message_uid, lore_raw_url_candidates,
-        parse_atom_timestamp, parse_fetch_flags, parse_fetch_modseq, parse_fetch_uid,
+        FixtureImapClient, GnuArchiveClient, GnuArchiveMonthEntry, GreetingKind, ImapClient,
+        ImapErrorKind, ImapSession, LoreImapClient, MailboxSnapshot, RemoteImapClient,
+        build_gnu_archive_incremental_mails, build_lore_incremental_mails,
+        collect_incremental_uids, ensure_tagged_ok, establish_http_connect_tunnel,
+        establish_socks5_tunnel, fetch_lore_raw_with, format_uid_sequence_set,
+        gnu_archive_message_uid, lore_raw_url_candidates, normalize_lore_message_url,
+        parse_atom_timestamp, parse_fetch_flags, parse_fetch_modseq, parse_fetch_uid, parse_flags,
+        parse_gnu_archive_index_response, parse_gnu_archive_listing_timestamp,
         parse_gnu_archive_mbox_messages, parse_gnu_archive_month_entries, parse_imap_proxy,
-        parse_literal_len, parse_lore_atom_entries, parse_status_code_u64,
-        select_gnu_archive_months,
+        parse_literal_len, parse_lore_atom_entries, parse_lore_feed_response,
+        parse_status_code_u64, parse_year_month_key, quote_imap_string, read_http_proxy_response,
+        select_gnu_archive_months, validate_gnu_archive_mbox_response,
     };
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -2223,6 +2317,165 @@ mod tests {
 
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
+        }
+    }
+
+    struct WriteFailsStream;
+
+    impl Read for WriteFailsStream {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    impl Write for WriteFailsStream {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "write failed",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FlushFailsStream;
+
+    impl Read for FlushFailsStream {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    impl Write for FlushFailsStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "flush failed",
+            ))
+        }
+    }
+
+    struct ReadFailsStream;
+
+    impl Read for ReadFailsStream {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "read failed",
+            ))
+        }
+    }
+
+    impl Write for ReadFailsStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct StubHttpResponse {
+        status_code: u16,
+        content_type: &'static str,
+        body: Vec<u8>,
+    }
+
+    impl StubHttpResponse {
+        fn text(status_code: u16, body: impl Into<String>) -> Self {
+            Self {
+                status_code,
+                content_type: "text/plain; charset=utf-8",
+                body: body.into().into_bytes(),
+            }
+        }
+
+        fn bytes(status_code: u16, body: impl Into<Vec<u8>>) -> Self {
+            Self {
+                status_code,
+                content_type: "application/octet-stream",
+                body: body.into(),
+            }
+        }
+    }
+
+    fn start_http_server<F>(
+        expected_requests: usize,
+        build_routes: F,
+    ) -> (String, thread::JoinHandle<()>)
+    where
+        F: FnOnce(&str) -> HashMap<String, StubHttpResponse>,
+    {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind http listener");
+        let base_url = format!("http://{}", listener.local_addr().expect("listener addr"));
+        let routes = build_routes(&base_url);
+        let handle = thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().expect("accept http request");
+                let path = read_http_request_path(&mut stream);
+                let response = routes
+                    .get(&path)
+                    .unwrap_or_else(|| panic!("unexpected HTTP path {path}"));
+                let reason = match response.status_code {
+                    200 => "OK",
+                    404 => "Not Found",
+                    _ => "Response",
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nContent-Type: {}\r\nConnection: close\r\n\r\n",
+                    response.status_code,
+                    reason,
+                    response.body.len(),
+                    response.content_type,
+                )
+                .expect("write HTTP headers");
+                stream.write_all(&response.body).expect("write HTTP body");
+                stream.flush().expect("flush HTTP response");
+            }
+        });
+
+        (base_url, handle)
+    }
+
+    fn read_http_request_path(stream: &mut impl Read) -> String {
+        let mut request = Vec::new();
+        let mut buf = [0u8; 1];
+        while !request.ends_with(b"\r\n\r\n") {
+            let read = stream.read(&mut buf).expect("read HTTP request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..read]);
+        }
+
+        let request_line = String::from_utf8_lossy(&request);
+        request_line
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/")
+            .to_string()
+    }
+
+    fn complete_imap_config(encryption: ImapEncryption) -> ImapConfig {
+        ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(993),
+            encryption: Some(encryption),
+            proxy: None,
         }
     }
 
@@ -2280,16 +2533,139 @@ mod tests {
     }
 
     #[test]
+    fn fixture_client_requires_connect_and_reports_invalid_sources() {
+        let missing_root = temp_dir("fixture-missing-root");
+        fs::remove_dir_all(&missing_root).expect("remove root");
+        let mut client = FixtureImapClient::new(missing_root.clone(), 1);
+        let error = client.connect().expect_err("missing root should fail");
+        assert!(error.to_string().contains("does not exist"));
+
+        let file_root = temp_dir("fixture-file-root");
+        let file_path = file_root.join("fixture.eml");
+        fs::write(&file_path, "mail").expect("write fixture file");
+        let mut file_client = FixtureImapClient::new(file_path.clone(), 1);
+        let error = file_client.connect().expect_err("file root should fail");
+        assert!(error.to_string().contains("is not a directory"));
+
+        let valid_root = temp_dir("fixture-disconnected");
+        fs::write(
+            valid_root.join("1.eml"),
+            "Message-ID: <disconnected@example.com>\nSubject: disconnected\n\nbody\n",
+        )
+        .expect("write fixture mail");
+        let mut disconnected = FixtureImapClient::new(valid_root.clone(), 1);
+        let error = disconnected
+            .select_mailbox("inbox")
+            .expect_err("select without connect should fail");
+        assert!(error.to_string().contains("client is not connected"));
+
+        disconnected.connect().expect("connect fixture");
+        fs::remove_dir_all(&valid_root).expect("remove fixture root after connect");
+        let error = disconnected
+            .select_mailbox("inbox")
+            .expect_err("missing mailbox directory should fail");
+        assert!(error.to_string().contains("mailbox directory"));
+
+        let _ = fs::remove_dir_all(file_root);
+    }
+
+    #[test]
+    fn fixture_client_scans_subdirectories_deduplicates_uids_and_parses_flags() {
+        let root = temp_dir("fixture-subdir");
+        let mailbox_dir = root.join("inbox");
+        fs::create_dir_all(&mailbox_dir).expect("create mailbox dir");
+        fs::write(
+            mailbox_dir.join("1-a.eml"),
+            "Message-ID: <a@example.com>\nSubject: a\nX-Flags: Seen, Flagged\n\nbody\n",
+        )
+        .expect("write first mail");
+        thread::sleep(Duration::from_millis(5));
+        fs::write(
+            mailbox_dir.join("1-b.eml"),
+            "Message-ID: <b@example.com>\nSubject: b\nX-Flags: Answered,\n Flagged\n\nbody\n",
+        )
+        .expect("write second mail");
+        fs::write(
+            mailbox_dir.join("note.eml"),
+            "Message-ID: <c@example.com>\nSubject: c\n\nbody\n",
+        )
+        .expect("write third mail");
+
+        let mut client = FixtureImapClient::new(root.clone(), 77);
+        client.connect().expect("connect");
+        let snapshot = client.select_mailbox("inbox").expect("select mailbox");
+        assert_eq!(snapshot.uidvalidity, 77);
+        assert_eq!(snapshot.highest_uid, 3);
+        assert!(snapshot.highest_modseq.is_some());
+
+        let fetched = client
+            .fetch_incremental("inbox", 0, None)
+            .expect("fetch fixture mail");
+        assert_eq!(
+            fetched.iter().map(|mail| mail.uid).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            fetched[0].flags,
+            vec!["Seen".to_string(), "Flagged".to_string()]
+        );
+        assert_eq!(
+            fetched[1].flags,
+            vec!["Answered".to_string(), "Flagged".to_string()]
+        );
+
+        let incremental = client
+            .fetch_incremental("inbox", 1, None)
+            .expect("fetch after uid");
+        assert_eq!(
+            incremental.iter().map(|mail| mail.uid).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn fixture_client_reports_invalid_uidvalidity_marker() {
+        let root = temp_dir("uidvalidity-invalid");
+        fs::write(root.join(".uidvalidity"), "not-a-number\n").expect("write marker");
+        fs::write(
+            root.join("1.eml"),
+            "Message-ID: <x@example.com>\nSubject: x\n\nbody\n",
+        )
+        .expect("write message");
+
+        let mut client = FixtureImapClient::new(root.clone(), 1);
+        client.connect().expect("connect");
+        let error = client
+            .select_mailbox("inbox")
+            .expect_err("invalid UIDVALIDITY should fail");
+        assert!(error.to_string().contains("invalid UIDVALIDITY value"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn blank_uidvalidity_marker_falls_back_to_default() {
+        let root = temp_dir("uidvalidity-blank");
+        fs::write(root.join(".uidvalidity"), " \n").expect("write marker");
+        fs::write(
+            root.join("1.eml"),
+            "Message-ID: <x@example.com>\nSubject: x\n\nbody\n",
+        )
+        .expect("write message");
+
+        let mut client = FixtureImapClient::new(root.clone(), 55);
+        client.connect().expect("connect");
+        let snapshot = client.select_mailbox("inbox").expect("select mailbox");
+        assert_eq!(snapshot.uidvalidity, 55);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn remote_client_accepts_complete_config() {
-        let client = RemoteImapClient::new(ImapConfig {
-            email: Some("me@example.com".to_string()),
-            user: Some("imap-user".to_string()),
-            pass: Some("imap-pass".to_string()),
-            server: Some("imap.example.com".to_string()),
-            server_port: Some(993),
-            encryption: Some(ImapEncryption::Tls),
-            proxy: None,
-        });
+        let client = RemoteImapClient::new(complete_imap_config(ImapEncryption::Tls));
 
         assert!(client.is_ok());
     }
@@ -2309,6 +2685,292 @@ mod tests {
         .expect("incomplete config should fail");
 
         assert!(error.to_string().contains("imap.pass"));
+    }
+
+    #[test]
+    fn lore_client_selects_and_fetches_incremental_from_local_server() {
+        let first_modseq = parse_atom_timestamp("2026-03-03T09:00:00+00:00").expect("first ts");
+        let second_modseq = parse_atom_timestamp("2026-03-03T10:00:00+00:00").expect("second ts");
+        let feed = r#"
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>https://lore.kernel.org/io-uring/msg-a/</id>
+    <updated>2026-03-03T09:00:00+00:00</updated>
+    <link rel="alternate" href="https://lore.kernel.org/io-uring/msg-a/" />
+  </entry>
+  <entry>
+    <id>https://lore.kernel.org/io-uring/msg-b/</id>
+    <updated>2026-03-03T10:00:00+00:00</updated>
+    <link rel="alternate" href="https://lore.kernel.org/io-uring/msg-b/" />
+  </entry>
+</feed>
+"#;
+        let base_url = "https://lore.test";
+        let mut client = LoreImapClient::new(Some(base_url)).expect("create lore client");
+        let error = client
+            .select_mailbox("io-uring")
+            .expect_err("select before connect should fail");
+        assert!(error.to_string().contains("client is not connected"));
+
+        client.connect().expect("connect lore");
+        assert_eq!(
+            client.feed_url("io-uring"),
+            "https://lore.test/io-uring/new.atom"
+        );
+        let entries = parse_lore_feed_response(&client.feed_url("io-uring"), 200, feed)
+            .expect("parse lore feed response");
+        let snapshot = MailboxSnapshot {
+            uidvalidity: 1,
+            highest_uid: 0,
+            highest_modseq: entries.iter().map(|entry| entry.modseq).max(),
+        };
+        assert_eq!(snapshot.uidvalidity, 1);
+        assert_eq!(snapshot.highest_uid, 0);
+        assert_eq!(snapshot.highest_modseq, Some(second_modseq));
+
+        let raw_by_url = HashMap::from([(
+            "https://lore.kernel.org/io-uring/msg-b/raw".to_string(),
+            b"Message-ID: <msg-b@example.com>\n\nbody\n".to_vec(),
+        )]);
+        let fetched = build_lore_incremental_mails(entries, Some(first_modseq), |message_url| {
+            fetch_lore_raw_with(message_url, |raw_url| {
+                Ok((200, raw_by_url.get(raw_url).cloned().unwrap_or_default()))
+            })
+        })
+        .expect("fetch incremental lore");
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].modseq, Some(second_modseq));
+        assert!(String::from_utf8_lossy(&fetched[0].raw).contains("msg-b@example.com"));
+    }
+
+    #[test]
+    fn lore_client_fetches_feed_and_raw_over_http() {
+        let first_modseq = parse_atom_timestamp("2026-03-03T09:00:00+00:00").expect("first ts");
+        let second_modseq = parse_atom_timestamp("2026-03-03T10:00:00+00:00").expect("second ts");
+        let (base_url, handle) = start_http_server(4, |base_url| {
+            let feed = format!(
+                r#"
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>{base_url}/io-uring/msg-a/</id>
+    <updated>2026-03-03T09:00:00+00:00</updated>
+    <link rel="alternate" href="{base_url}/io-uring/msg-a/" />
+  </entry>
+  <entry>
+    <id>{base_url}/io-uring/msg-b/</id>
+    <updated>2026-03-03T10:00:00+00:00</updated>
+    <link rel="alternate" href="{base_url}/io-uring/msg-b/" />
+  </entry>
+</feed>
+"#
+            );
+            HashMap::from([
+                (
+                    "/io-uring/new.atom".to_string(),
+                    StubHttpResponse::text(200, feed),
+                ),
+                (
+                    "/io-uring/msg-b/raw".to_string(),
+                    StubHttpResponse::text(404, ""),
+                ),
+                (
+                    "/io-uring/msg-b/raw/".to_string(),
+                    StubHttpResponse::bytes(
+                        200,
+                        b"Message-ID: <msg-b@example.com>\nSubject: message b\n\nbody\n".to_vec(),
+                    ),
+                ),
+            ])
+        });
+
+        let mut client = LoreImapClient::new(Some(&base_url)).expect("create lore client");
+        client.connect().expect("connect lore");
+
+        let snapshot = client
+            .select_mailbox("/io-uring/")
+            .expect("select lore mailbox");
+        assert_eq!(snapshot.uidvalidity, 1);
+        assert_eq!(snapshot.highest_uid, 0);
+        assert_eq!(snapshot.highest_modseq, Some(second_modseq));
+
+        let fetched = client
+            .fetch_incremental("io-uring", 0, Some(first_modseq))
+            .expect("fetch lore mails");
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].modseq, Some(second_modseq));
+        assert!(String::from_utf8_lossy(&fetched[0].raw).contains("msg-b@example.com"));
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
+    fn lore_client_reports_feed_http_errors_from_server() {
+        let (base_url, handle) = start_http_server(1, |_| {
+            HashMap::from([(
+                "/broken/new.atom".to_string(),
+                StubHttpResponse::text(404, "missing mailbox"),
+            )])
+        });
+
+        let mut client = LoreImapClient::new(Some(&base_url)).expect("create lore client");
+        client.connect().expect("connect lore");
+
+        let error = client
+            .select_mailbox("broken")
+            .expect_err("HTTP errors should fail mailbox selection");
+        assert!(error.to_string().contains("HTTP 404"));
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
+    fn lore_client_reports_empty_raw_message_after_trying_candidates() {
+        let error = fetch_lore_raw_with("https://lore.kernel.org/io-uring/msg-empty/", |_| {
+            Ok((200, Vec::new()))
+        })
+        .expect_err("empty raw should fail");
+        assert!(error.to_string().contains("lore raw message is empty"));
+    }
+
+    #[test]
+    fn gnu_archive_client_selects_and_fetches_incremental_from_local_server() {
+        let feb_modseq =
+            parse_gnu_archive_listing_timestamp("2026-02-26", "09:12").expect("feb timestamp");
+        let html = r#"
+<pre>
+<a href="2026-02">2026-02</a> 2026-02-26 09:12  855K
+<a href="2026-03">2026-03</a> 2026-03-07 06:37  341K
+</pre>
+"#;
+        let mbox = b"From MAILER-DAEMON Tue Mar 03 04:39:31 2026\nMessage-ID: <msg-a@example.com>\nSubject: one\n\nbody\nFrom MAILER-DAEMON Tue Mar 03 04:40:31 2026\nMessage-ID: <msg-b@example.com>\nSubject: two\n\nbody two\n";
+        let mut client =
+            GnuArchiveClient::new(Some("https://archive.test")).expect("create archive client");
+        let error = client
+            .select_mailbox("mailbox")
+            .expect_err("select before connect should fail");
+        assert!(error.to_string().contains("client is not connected"));
+
+        client.connect().expect("connect archive");
+        assert_eq!(client.index_url("mailbox"), "https://archive.test/mailbox/");
+        assert_eq!(
+            client.month_url("mailbox", "2026-03"),
+            "https://archive.test/mailbox/2026-03"
+        );
+        let months = parse_gnu_archive_index_response(&client.index_url("mailbox"), 200, html)
+            .expect("parse archive index");
+        let snapshot = MailboxSnapshot {
+            uidvalidity: 1,
+            highest_uid: 0,
+            highest_modseq: months.iter().map(|entry| entry.modseq).max(),
+        };
+        assert_eq!(snapshot.uidvalidity, 1);
+        assert_eq!(snapshot.highest_uid, 0);
+        assert!(snapshot.highest_modseq.is_some());
+
+        let fetched = build_gnu_archive_incremental_mails(&months, Some(feb_modseq), |month_key| {
+            let url = client.month_url("mailbox", month_key);
+            validate_gnu_archive_mbox_response(&url, 200, mbox.to_vec())
+        })
+        .expect("fetch gnu archive");
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched[0].uid, 314_000_001);
+        assert_eq!(fetched[1].uid, 314_000_002);
+    }
+
+    #[test]
+    fn gnu_archive_client_fetches_index_and_mbox_over_http() {
+        let feb_modseq =
+            parse_gnu_archive_listing_timestamp("2026-02-26", "09:12").expect("feb timestamp");
+        let (base_url, handle) = start_http_server(3, |_| {
+            let html = r#"
+<pre>
+<a href="2026-02">2026-02</a> 2026-02-26 09:12  855K
+<a href="2026-03">2026-03</a> 2026-03-07 06:37  341K
+</pre>
+"#;
+            let mbox = b"From MAILER-DAEMON Tue Mar 03 04:39:31 2026\nMessage-ID: <msg-a@example.com>\nSubject: one\n\nbody\nFrom MAILER-DAEMON Tue Mar 03 04:40:31 2026\nMessage-ID: <msg-b@example.com>\nSubject: two\n\nbody two\n";
+            HashMap::from([
+                ("/mailbox/".to_string(), StubHttpResponse::text(200, html)),
+                (
+                    "/mailbox/2026-03".to_string(),
+                    StubHttpResponse::bytes(200, mbox.to_vec()),
+                ),
+            ])
+        });
+
+        let mut client = GnuArchiveClient::new(Some(&base_url)).expect("create archive client");
+        client.connect().expect("connect archive");
+
+        let snapshot = client
+            .select_mailbox("/mailbox/")
+            .expect("select archive mailbox");
+        assert_eq!(snapshot.uidvalidity, 1);
+        assert_eq!(snapshot.highest_uid, 0);
+        assert!(snapshot.highest_modseq.is_some());
+
+        let fetched = client
+            .fetch_incremental("mailbox", 0, Some(feb_modseq))
+            .expect("fetch archive month");
+        assert_eq!(
+            fetched.iter().map(|mail| mail.uid).collect::<Vec<_>>(),
+            vec![314_000_001, 314_000_002]
+        );
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
+    fn gnu_archive_client_reports_mbox_http_errors_from_server() {
+        let feb_modseq =
+            parse_gnu_archive_listing_timestamp("2026-02-26", "09:12").expect("feb timestamp");
+        let (base_url, handle) = start_http_server(2, |_| {
+            let html = r#"
+<pre>
+<a href="2026-02">2026-02</a> 2026-02-26 09:12  855K
+<a href="2026-03">2026-03</a> 2026-03-07 06:37  341K
+</pre>
+"#;
+            HashMap::from([
+                ("/mailbox/".to_string(), StubHttpResponse::text(200, html)),
+                (
+                    "/mailbox/2026-03".to_string(),
+                    StubHttpResponse::text(404, "month not found"),
+                ),
+            ])
+        });
+
+        let mut client = GnuArchiveClient::new(Some(&base_url)).expect("create archive client");
+        client.connect().expect("connect archive");
+
+        let error = client
+            .fetch_incremental("mailbox", 0, Some(feb_modseq))
+            .expect_err("HTTP errors should fail archive fetch");
+        assert!(error.to_string().contains("HTTP 404"));
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
+    fn http_clients_surface_transport_errors_before_receiving_responses() {
+        let mut lore_client =
+            LoreImapClient::new(Some("http://127.0.0.1:1")).expect("create lore client");
+        lore_client.connect().expect("connect lore");
+        let lore_error = lore_client
+            .select_mailbox("io-uring")
+            .expect_err("missing listener should fail feed fetch");
+        assert!(lore_error.to_string().contains("failed to fetch lore feed"));
+
+        let mut archive_client =
+            GnuArchiveClient::new(Some("http://127.0.0.1:1")).expect("create archive client");
+        archive_client.connect().expect("connect archive");
+        let archive_error = archive_client
+            .select_mailbox("mailbox")
+            .expect_err("missing listener should fail archive fetch");
+        assert!(
+            archive_error
+                .to_string()
+                .contains("failed to fetch GNU archive index")
+        );
     }
 
     #[test]
@@ -2371,6 +3033,38 @@ mod tests {
     }
 
     #[test]
+    fn imap_proxy_parser_rejects_invalid_proxy_urls() {
+        let proxy = parse_imap_proxy("http://127.0.0.1").expect("default http port");
+        assert_eq!(proxy.redacted_url(), "http://127.0.0.1:80");
+        let socks_proxy = parse_imap_proxy("socks5h://127.0.0.1").expect("default socks5 port");
+        assert_eq!(socks_proxy.redacted_url(), "socks5://127.0.0.1:1080");
+
+        let unsupported =
+            parse_imap_proxy("https://127.0.0.1:443").expect_err("unsupported scheme should fail");
+        assert!(
+            unsupported
+                .to_string()
+                .contains("unsupported IMAP proxy scheme")
+        );
+
+        let auth = parse_imap_proxy("http://user:pass@127.0.0.1:8080")
+            .expect_err("proxy auth should fail");
+        assert!(auth.to_string().contains("authentication is not supported"));
+
+        let path_error =
+            parse_imap_proxy("http://127.0.0.1:8080/proxy").expect_err("path should fail");
+        assert!(
+            path_error
+                .to_string()
+                .contains("remove path, query, and fragment")
+        );
+
+        let missing_host =
+            parse_imap_proxy("http:///").expect_err("missing host should fail proxy parsing");
+        assert!(missing_host.to_string().contains("invalid IMAP proxy URL"));
+    }
+
+    #[test]
     fn http_proxy_connect_tunnels_imap_socket() {
         let proxy = parse_imap_proxy("http://127.0.0.1:7890").expect("parse proxy");
         let mut stream = MockStream::with_reads(b"HTTP/1.1 200 Connection established\r\n\r\n");
@@ -2381,6 +3075,64 @@ mod tests {
         let request_text = String::from_utf8(stream.writes).expect("request utf8");
         assert!(request_text.starts_with("CONNECT imap.gmail.com:993 HTTP/1.1\r\n"));
         assert!(request_text.contains("\r\nHost: imap.gmail.com:993\r\n"));
+    }
+
+    #[test]
+    fn http_proxy_helpers_report_truncated_and_rejected_responses() {
+        let proxy = parse_imap_proxy("http://127.0.0.1:7890").expect("parse proxy");
+
+        let mut truncated = MockStream::default();
+        let error = read_http_proxy_response(&mut truncated, &proxy, "imap.gmail.com:993")
+            .expect_err("truncated response should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("closed the connection before CONNECT")
+        );
+
+        let mut rejected = MockStream::with_reads(b"HTTP/1.1 403 Forbidden\r\n\r\n");
+        let error = establish_http_connect_tunnel(&mut rejected, &proxy, "imap.gmail.com", 993)
+            .expect_err("non-2xx connect should fail");
+        assert!(error.to_string().contains("rejected CONNECT"));
+
+        let oversized = vec![b'a'; super::HTTP_PROXY_RESPONSE_MAX_BYTES + 1];
+        let mut oversized_stream = MockStream::with_reads(&oversized);
+        let error = read_http_proxy_response(&mut oversized_stream, &proxy, "imap.gmail.com:993")
+            .expect_err("oversized responses should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("sent too much HTTP response data")
+        );
+
+        let mut read_error_stream = ReadFailsStream;
+        let error = read_http_proxy_response(&mut read_error_stream, &proxy, "imap.gmail.com:993")
+            .expect_err("proxy read failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed while reading IMAP proxy")
+        );
+
+        let mut write_error_stream = WriteFailsStream;
+        let error =
+            establish_http_connect_tunnel(&mut write_error_stream, &proxy, "imap.gmail.com", 993)
+                .expect_err("write failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to send IMAP CONNECT request")
+        );
+
+        let mut flush_error_stream = FlushFailsStream;
+        let error =
+            establish_http_connect_tunnel(&mut flush_error_stream, &proxy, "imap.gmail.com", 993)
+                .expect_err("flush failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to flush IMAP CONNECT request")
+        );
     }
 
     #[test]
@@ -2403,6 +3155,498 @@ mod tests {
                 0x05, 0x01, 0x00, 0x03, 14, b'i', b'm', b'a', b'p', b'.', b'g', b'm', b'a', b'i',
                 b'l', b'.', b'c', b'o', b'm', 0x03, 0xe1
             ]
+        );
+    }
+
+    #[test]
+    fn socks5_proxy_reports_handshake_and_connect_failures() {
+        let proxy = parse_imap_proxy("socks5://127.0.0.1:7890").expect("parse proxy");
+
+        let mut invalid_version = MockStream::with_reads(&[0x04, 0x00]);
+        let error = establish_socks5_tunnel(&mut invalid_version, &proxy, "imap.gmail.com", 993)
+            .expect_err("invalid version should fail");
+        assert!(error.to_string().contains("invalid SOCKS5 version"));
+
+        let mut unauthenticated = MockStream::with_reads(&[0x05, 0x02]);
+        let error = establish_socks5_tunnel(&mut unauthenticated, &proxy, "imap.gmail.com", 993)
+            .expect_err("auth required should fail");
+        assert!(error.to_string().contains("does not allow unauthenticated"));
+
+        let mut connect_failed = MockStream::with_reads(&[0x05, 0x00, 0x05, 0x05, 0x00]);
+        let error = establish_socks5_tunnel(&mut connect_failed, &proxy, "imap.gmail.com", 993)
+            .expect_err("connect reply should fail");
+        assert!(error.to_string().contains("connection refused"));
+
+        let mut greeting_read_error = ReadFailsStream;
+        let error =
+            establish_socks5_tunnel(&mut greeting_read_error, &proxy, "imap.gmail.com", 993)
+                .expect_err("greeting read failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read SOCKS5 greeting reply")
+        );
+
+        let mut greeting_write_error = WriteFailsStream;
+        let error =
+            establish_socks5_tunnel(&mut greeting_write_error, &proxy, "imap.gmail.com", 993)
+                .expect_err("greeting write failures should surface");
+        assert!(error.to_string().contains("failed to send SOCKS5 greeting"));
+
+        let too_long_host = "a".repeat(256);
+        let mut host_length_stream = MockStream::with_reads(&[0x05, 0x00]);
+        let error = establish_socks5_tunnel(&mut host_length_stream, &proxy, &too_long_host, 993)
+            .expect_err("long hostnames should fail");
+        assert!(error.to_string().contains("too long for SOCKS5 proxying"));
+    }
+
+    #[test]
+    fn socks5_reply_address_reports_decode_failures() {
+        let proxy = parse_imap_proxy("socks5://127.0.0.1:7890").expect("parse proxy");
+
+        let mut atyp_error = ReadFailsStream;
+        let error = super::read_socks5_reply_address(&mut atyp_error, &proxy)
+            .expect_err("ATYP read failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read SOCKS5 reply type")
+        );
+
+        let mut domain_length_error = MockStream::with_reads(&[0x03]);
+        let error = super::read_socks5_reply_address(&mut domain_length_error, &proxy)
+            .expect_err("domain length failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read SOCKS5 domain length")
+        );
+
+        let mut bind_address_error = MockStream::with_reads(&[0x01]);
+        let error = super::read_socks5_reply_address(&mut bind_address_error, &proxy)
+            .expect_err("bind address failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read SOCKS5 bind address")
+        );
+    }
+
+    #[test]
+    fn imap_session_executes_command_flow_over_mock_transport() {
+        let responses = concat!(
+            "* OK hello\r\n",
+            "* CAPABILITY IMAP4rev1 CONDSTORE\r\n",
+            "A0001 OK capability\r\n",
+            "A0002 OK login\r\n",
+            "* OK [UIDVALIDITY 77] valid\r\n",
+            "* OK [UIDNEXT 42] next\r\n",
+            "* OK [HIGHESTMODSEQ 9001] modseq\r\n",
+            "A0003 OK select\r\n",
+            "* SEARCH 4 5 5 9\r\n",
+            "A0004 OK search\r\n",
+            "* 1 FETCH (UID 4 FLAGS (\\Seen \\Answered) MODSEQ (20) BODY.PEEK[] {5}\r\n",
+            "hello\r\n",
+            ")\r\n",
+            "A0005 OK fetch\r\n"
+        );
+        let mut session =
+            ImapSession::with_mock_stream(MockStream::with_reads(responses.as_bytes()));
+
+        assert_eq!(
+            session.read_greeting().expect("read greeting"),
+            GreetingKind::Ok
+        );
+        let capabilities = session.fetch_capabilities().expect("fetch capabilities");
+        assert!(capabilities.contains("IMAP4REV1"));
+        assert!(capabilities.contains("CONDSTORE"));
+        session.capabilities = capabilities;
+
+        let config = ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(993),
+            encryption: Some(ImapEncryption::Tls),
+            proxy: None,
+        };
+        session.login(&config).expect("login");
+
+        let snapshot = session.select_mailbox("INBOX").expect("select");
+        assert_eq!(snapshot.uidvalidity, 77);
+        assert_eq!(snapshot.highest_uid, 41);
+        assert_eq!(snapshot.highest_modseq, Some(9001));
+
+        let uids = session.search_uid_range(4).expect("search uids");
+        assert_eq!(uids, vec![4, 5, 9]);
+
+        let fetched = session.fetch_uids(&[4], "BODY.PEEK[]").expect("fetch uids");
+        assert_eq!(fetched.len(), 1);
+        assert_eq!(fetched[0].uid, 4);
+        assert_eq!(fetched[0].modseq, Some(20));
+        assert_eq!(
+            fetched[0].flags,
+            vec!["\\Seen".to_string(), "\\Answered".to_string()]
+        );
+        assert_eq!(fetched[0].raw, b"hello".to_vec());
+    }
+
+    #[test]
+    fn imap_session_handles_greeting_login_and_fetch_failures() {
+        let mut bye_session =
+            ImapSession::with_mock_stream(MockStream::with_reads(b"* BYE go away\r\n"));
+        let error = bye_session
+            .read_greeting()
+            .expect_err("BYE greeting should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("server closed connection during greeting")
+        );
+
+        let mut plaintext_session = ImapSession::with_mock_stream(MockStream::default());
+        plaintext_session
+            .capabilities
+            .insert("LOGINDISABLED".to_string());
+        let config = ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(143),
+            encryption: Some(ImapEncryption::None),
+            proxy: None,
+        };
+        let error = plaintext_session
+            .login(&config)
+            .expect_err("plaintext login should be rejected");
+        assert!(error.to_string().contains("disallows LOGIN over plaintext"));
+
+        let mut fetch_session = ImapSession::with_mock_stream(MockStream::with_reads(
+            b"* 1 FETCH (FLAGS (\\Seen) BODY.PEEK[] {5}\r\nhello\r\n)\r\nA0001 OK fetch\r\n",
+        ));
+        let error = fetch_session
+            .fetch_uid_chunk(&[4], "BODY.PEEK[]")
+            .expect_err("missing UID should fail");
+        assert!(error.to_string().contains("missing UID in FETCH response"));
+
+        let mut eof_session = ImapSession::with_mock_stream(MockStream::default());
+        let error = eof_session
+            .read_line_string()
+            .expect_err("EOF while reading line should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unexpected EOF while reading IMAP response")
+        );
+    }
+
+    #[test]
+    fn imap_session_covers_misc_defaults_and_protocol_edges() {
+        let mut preauth_session =
+            ImapSession::with_mock_stream(MockStream::with_reads(b"* PREAUTH welcome\r\n"));
+        assert_eq!(
+            preauth_session.read_greeting().expect("PREAUTH greeting"),
+            GreetingKind::Preauth
+        );
+
+        let mut unexpected_session =
+            ImapSession::with_mock_stream(MockStream::with_reads(b"* WHAT welcome\r\n"));
+        let error = unexpected_session
+            .read_greeting()
+            .expect_err("unexpected greeting should fail");
+        assert!(error.to_string().contains("unexpected IMAP greeting"));
+
+        let mut missing_user_session = ImapSession::with_mock_stream(MockStream::default());
+        let error = missing_user_session
+            .login(&ImapConfig {
+                email: None,
+                user: None,
+                pass: Some("imap-pass".to_string()),
+                server: Some("imap.example.com".to_string()),
+                server_port: Some(993),
+                encryption: Some(ImapEncryption::Tls),
+                proxy: None,
+            })
+            .expect_err("missing user should fail");
+        assert!(error.to_string().contains("missing imap.user"));
+
+        let mut missing_pass_session = ImapSession::with_mock_stream(MockStream::default());
+        let error = missing_pass_session
+            .login(&ImapConfig {
+                email: Some("me@example.com".to_string()),
+                user: Some("imap-user".to_string()),
+                pass: None,
+                server: Some("imap.example.com".to_string()),
+                server_port: Some(993),
+                encryption: Some(ImapEncryption::Tls),
+                proxy: None,
+            })
+            .expect_err("missing pass should fail");
+        assert!(error.to_string().contains("missing imap.pass"));
+
+        let mut default_select = ImapSession::with_mock_stream(MockStream::with_reads(
+            b"* FLAGS (\\Seen)\r\nA0001 OK [READ-WRITE] select\r\n",
+        ));
+        let snapshot = default_select
+            .select_mailbox("INBOX")
+            .expect("select mailbox with defaults");
+        assert_eq!(snapshot.uidvalidity, 1);
+        assert_eq!(snapshot.highest_uid, 0);
+        assert_eq!(snapshot.highest_modseq, None);
+
+        let mut noisy_search = ImapSession::with_mock_stream(MockStream::with_reads(
+            b"* OK noop\r\n* SEARCH 7 nope 9\r\nA0001 OK search\r\n",
+        ));
+        let uids = noisy_search.search_uid_range(7).expect("search with noise");
+        assert_eq!(uids, vec![7, 9]);
+
+        let mut empty_fetches = ImapSession::with_mock_stream(MockStream::default());
+        assert!(
+            empty_fetches
+                .fetch_uids(&[], "BODY.PEEK[]")
+                .expect("empty uid list")
+                .is_empty()
+        );
+        assert!(
+            empty_fetches
+                .fetch_uid_chunk(&[], "BODY.PEEK[]")
+                .expect("empty uid chunk")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn imap_session_reports_fetch_trailer_and_io_failures() {
+        let mut missing_literal = ImapSession::with_mock_stream(MockStream::with_reads(
+            b"* 1 FETCH (UID 4 FLAGS (\\Seen) BODY.PEEK[]\r\nA0001 OK fetch\r\n",
+        ));
+        let error = missing_literal
+            .fetch_uid_chunk(&[4], "BODY.PEEK[]")
+            .expect_err("missing literal should fail");
+        assert!(error.to_string().contains("missing literal size"));
+
+        let mut truncated_trailer = ImapSession::with_mock_stream(MockStream::with_reads(
+            b"* 1 FETCH (UID 4 FLAGS (\\Seen) MODSEQ (20) BODY.PEEK[] {5}\r\nhello\r\nA0001 OK fetch\r\n",
+        ));
+        let error = truncated_trailer
+            .fetch_uid_chunk(&[4], "BODY.PEEK[]")
+            .expect_err("truncated trailer should fail");
+        assert!(error.to_string().contains("truncated FETCH trailer"));
+
+        let mut write_error_session = ImapSession::with_mock_stream(WriteFailsStream);
+        let error = write_error_session
+            .write_command("A0001", "NOOP")
+            .expect_err("write failures should surface");
+        assert!(error.to_string().contains("failed to write IMAP command"));
+
+        let mut flush_error_session = ImapSession::with_mock_stream(FlushFailsStream);
+        let error = flush_error_session
+            .write_command("A0001", "NOOP")
+            .expect_err("flush failures should surface");
+        assert!(error.to_string().contains("failed to flush IMAP command"));
+
+        let mut read_line_error_session = ImapSession::with_mock_stream(ReadFailsStream);
+        let error = read_line_error_session
+            .read_line_bytes()
+            .expect_err("socket read failures should surface");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read from IMAP socket")
+        );
+
+        let mut read_literal_error_session = ImapSession::with_mock_stream(ReadFailsStream);
+        let error = read_literal_error_session
+            .read_exact_bytes(4)
+            .expect_err("literal read failures should surface");
+        assert!(error.to_string().contains("failed to read IMAP literal"));
+    }
+
+    #[test]
+    fn collect_incremental_uids_merges_uid_and_modseq_search_results() {
+        let responses = concat!(
+            "* SEARCH 7 8\r\n",
+            "A0001 OK search\r\n",
+            "* SEARCH 8 9\r\n",
+            "A0002 OK search\r\n"
+        );
+        let mut session =
+            ImapSession::with_mock_stream(MockStream::with_reads(responses.as_bytes()));
+        let snapshot = MailboxSnapshot {
+            uidvalidity: 1,
+            highest_uid: 9,
+            highest_modseq: Some(30),
+        };
+
+        let uids = collect_incremental_uids(&mut session, snapshot, 6, Some(20))
+            .expect("collect incremental uids");
+        assert_eq!(uids, vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn imap_session_connect_rejects_missing_runtime_fields() {
+        let missing_server = ImapSession::connect(&ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: None,
+            server_port: Some(993),
+            encryption: Some(ImapEncryption::Tls),
+            proxy: None,
+        })
+        .err()
+        .expect("missing server should fail");
+        assert!(missing_server.to_string().contains("missing imap.server"));
+
+        let missing_port = ImapSession::connect(&ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: None,
+            encryption: Some(ImapEncryption::Tls),
+            proxy: None,
+        })
+        .err()
+        .expect("missing port should fail");
+        assert!(missing_port.to_string().contains("missing imap.serverport"));
+
+        let missing_encryption = ImapSession::connect(&ImapConfig {
+            email: Some("me@example.com".to_string()),
+            user: Some("imap-user".to_string()),
+            pass: Some("imap-pass".to_string()),
+            server: Some("imap.example.com".to_string()),
+            server_port: Some(993),
+            encryption: None,
+            proxy: None,
+        })
+        .err()
+        .expect("missing encryption should fail");
+        assert!(
+            missing_encryption
+                .to_string()
+                .contains("missing imap.encryption")
+        );
+    }
+
+    #[test]
+    fn remote_client_requires_connected_session_and_delegates_requests() {
+        let config = complete_imap_config(ImapEncryption::Tls);
+
+        let mut disconnected =
+            RemoteImapClient::new(config.clone()).expect("create disconnected remote client");
+        let error = disconnected
+            .select_mailbox("INBOX")
+            .expect_err("missing session should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("remote IMAP session is not connected")
+        );
+
+        let mut select_client = RemoteImapClient {
+            config: config.clone(),
+            session: Some(ImapSession::with_mock_stream(MockStream::with_reads(
+                concat!(
+                    "* OK [UIDVALIDITY 11] valid\r\n",
+                    "* OK [UIDNEXT 4] next\r\n",
+                    "* OK [HIGHESTMODSEQ 22] modseq\r\n",
+                    "A0001 OK select\r\n"
+                )
+                .as_bytes(),
+            ))),
+        };
+        let snapshot = select_client
+            .select_mailbox("INBOX")
+            .expect("delegate mailbox selection");
+        assert_eq!(snapshot.uidvalidity, 11);
+        assert_eq!(snapshot.highest_uid, 3);
+        assert_eq!(snapshot.highest_modseq, Some(22));
+
+        let mut incremental_client = RemoteImapClient {
+            config: config.clone(),
+            session: Some(ImapSession::with_mock_stream(MockStream::with_reads(
+                concat!(
+                    "* OK [UIDVALIDITY 11] valid\r\n",
+                    "* OK [UIDNEXT 4] next\r\n",
+                    "* OK [HIGHESTMODSEQ 22] modseq\r\n",
+                    "A0001 OK select\r\n",
+                    "* SEARCH 2 3\r\n",
+                    "A0002 OK search\r\n",
+                    "* SEARCH 3\r\n",
+                    "A0003 OK search\r\n",
+                    "* 1 FETCH (UID 2 FLAGS (\\Seen) MODSEQ (21) BODY.PEEK[] {5}\r\n",
+                    "hello\r\n",
+                    ")\r\n",
+                    "* 2 FETCH (UID 3 FLAGS (\\Seen) MODSEQ (22) BODY.PEEK[] {5}\r\n",
+                    "world\r\n",
+                    ")\r\n",
+                    "A0004 OK fetch\r\n"
+                )
+                .as_bytes(),
+            ))),
+        };
+        let fetched = incremental_client
+            .fetch_incremental("INBOX", 1, Some(20))
+            .expect("delegate incremental fetch");
+        assert_eq!(
+            fetched.iter().map(|mail| mail.uid).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+
+        let mut header_client = RemoteImapClient {
+            config: config.clone(),
+            session: Some(ImapSession::with_mock_stream(MockStream::with_reads(
+                concat!(
+                    "* OK [UIDVALIDITY 11] valid\r\n",
+                    "* OK [UIDNEXT 8] next\r\n",
+                    "* OK [HIGHESTMODSEQ 22] modseq\r\n",
+                    "A0001 OK select\r\n",
+                    "* SEARCH 7\r\n",
+                    "A0002 OK search\r\n",
+                    "* 1 FETCH (UID 7 FLAGS (\\Seen) MODSEQ (22) BODY.PEEK[HEADER.FIELDS (MESSAGE-ID SUBJECT FROM DATE IN-REPLY-TO REFERENCES LIST-ID)] {5}\r\n",
+                    "headr\r\n",
+                    ")\r\n",
+                    "A0003 OK fetch\r\n"
+                )
+                .as_bytes(),
+            ))),
+        };
+        let header_candidates = header_client
+            .fetch_header_candidates("INBOX", 6, None)
+            .expect("delegate header fetch");
+        assert_eq!(
+            header_candidates
+                .iter()
+                .map(|mail| mail.uid)
+                .collect::<Vec<_>>(),
+            vec![7]
+        );
+
+        let mut full_uid_client = RemoteImapClient {
+            config,
+            session: Some(ImapSession::with_mock_stream(MockStream::with_reads(
+                concat!(
+                    "* OK [UIDVALIDITY 11] valid\r\n",
+                    "* OK [UIDNEXT 10] next\r\n",
+                    "* OK [HIGHESTMODSEQ 22] modseq\r\n",
+                    "A0001 OK select\r\n",
+                    "* 1 FETCH (UID 9 FLAGS (\\Seen) MODSEQ (22) BODY.PEEK[] {4}\r\n",
+                    "full\r\n",
+                    ")\r\n",
+                    "A0002 OK fetch\r\n"
+                )
+                .as_bytes(),
+            ))),
+        };
+        let full = full_uid_client
+            .fetch_full_uids("INBOX", &[9])
+            .expect("delegate full UID fetch");
+        assert_eq!(
+            full.iter().map(|mail| mail.uid).collect::<Vec<_>>(),
+            vec![9]
         );
     }
 
@@ -2446,6 +3690,32 @@ mod tests {
     fn parses_atom_timestamps() {
         let ts = parse_atom_timestamp("2026-03-03T10:00:00+00:00").expect("timestamp");
         assert!(ts > 0);
+    }
+
+    #[test]
+    fn parsing_helpers_cover_url_normalization_dates_and_flags() {
+        assert_eq!(quote_imap_string(r#"a"b\c"#), r#""a\"b\\c""#);
+        assert_eq!(
+            normalize_lore_message_url("https://lore.kernel.org/io-uring/msg/#fragment?query=1")
+                .as_deref(),
+            Some("https://lore.kernel.org/io-uring/msg/")
+        );
+        assert_eq!(normalize_lore_message_url("not-a-url"), None);
+
+        assert_eq!(parse_year_month_key("2026-03"), Some((2026, 3)));
+        assert_eq!(parse_year_month_key("2026-13"), None);
+        assert!(parse_gnu_archive_listing_timestamp("2026-03-07", "06:37").is_some());
+
+        assert_eq!(
+            parse_flags(
+                b"Message-ID: <x@example.com>\r\nX-Flags: Seen,\r\n Flagged Answered\r\n\r\nbody\r\n"
+            ),
+            vec![
+                "Seen".to_string(),
+                "Flagged".to_string(),
+                "Answered".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/infra/imap.rs
+++ b/src/infra/imap.rs
@@ -399,6 +399,10 @@ impl LoreImapClient {
                 )
             })?;
             let status_code = response.status().as_u16();
+            if !(200..300).contains(&status_code) {
+                return Ok((status_code, Vec::new()));
+            }
+
             let bytes = response.bytes().map_err(|error| {
                 CriewError::with_source(
                     ErrorCode::Imap,
@@ -607,6 +611,8 @@ impl GnuArchiveClient {
         })?;
 
         let status_code = response.status().as_u16();
+        validate_gnu_archive_mbox_response(&url, status_code)?;
+
         let bytes = response
             .bytes()
             .map(|bytes| bytes.to_vec())
@@ -618,7 +624,7 @@ impl GnuArchiveClient {
                 )
             })?;
 
-        validate_gnu_archive_mbox_response(&url, status_code, bytes)
+        Ok(bytes)
     }
 }
 
@@ -637,11 +643,7 @@ fn parse_gnu_archive_index_response(
     parse_gnu_archive_month_entries(body)
 }
 
-fn validate_gnu_archive_mbox_response(
-    url: &str,
-    status_code: u16,
-    body: Vec<u8>,
-) -> Result<Vec<u8>> {
+fn validate_gnu_archive_mbox_response(url: &str, status_code: u16) -> Result<()> {
     if !(200..300).contains(&status_code) {
         return Err(imap_error(
             ImapErrorKind::Protocol,
@@ -649,7 +651,7 @@ fn validate_gnu_archive_mbox_response(
         ));
     }
 
-    Ok(body)
+    Ok(())
 }
 
 fn build_gnu_archive_incremental_mails<F>(
@@ -2447,6 +2449,30 @@ mod tests {
         (base_url, handle)
     }
 
+    fn start_http_server_with_raw_responses<F>(
+        expected_requests: usize,
+        build_response: F,
+    ) -> (String, thread::JoinHandle<()>)
+    where
+        F: Fn(&str) -> Vec<u8> + Send + 'static,
+    {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind http listener");
+        let base_url = format!("http://{}", listener.local_addr().expect("listener addr"));
+        let handle = thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().expect("accept http request");
+                let path = read_http_request_path(&mut stream);
+                let response = build_response(&path);
+                stream
+                    .write_all(&response)
+                    .expect("write raw HTTP response");
+                stream.flush().expect("flush raw HTTP response");
+            }
+        });
+
+        (base_url, handle)
+    }
+
     fn read_http_request_path(stream: &mut impl Read) -> String {
         let mut request = Vec::new();
         let mut buf = [0u8; 1];
@@ -2824,6 +2850,26 @@ mod tests {
     }
 
     #[test]
+    fn lore_client_checks_status_before_reading_error_body() {
+        let (base_url, handle) = start_http_server_with_raw_responses(2, move |path| {
+            match path {
+            "/io-uring/msg-b/raw" | "/io-uring/msg-b/raw/" => b"HTTP/1.1 404 Not Found\r\nContent-Length: 64\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\nshort".to_vec(),
+            _ => panic!("unexpected HTTP path {path}"),
+        }
+        });
+
+        let mut client = LoreImapClient::new(Some(&base_url)).expect("create lore client");
+        client.connect().expect("connect lore");
+
+        let error = client
+            .fetch_raw_mail(&format!("{base_url}/io-uring/msg-b/"))
+            .expect_err("HTTP status should fail before reading body");
+        assert!(error.to_string().contains("HTTP 404"));
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
     fn lore_client_reports_empty_raw_message_after_trying_candidates() {
         let error = fetch_lore_raw_with("https://lore.kernel.org/io-uring/msg-empty/", |_| {
             Ok((200, Vec::new()))
@@ -2869,7 +2915,8 @@ mod tests {
 
         let fetched = build_gnu_archive_incremental_mails(&months, Some(feb_modseq), |month_key| {
             let url = client.month_url("mailbox", month_key);
-            validate_gnu_archive_mbox_response(&url, 200, mbox.to_vec())
+            validate_gnu_archive_mbox_response(&url, 200)?;
+            Ok(mbox.to_vec())
         })
         .expect("fetch gnu archive");
         assert_eq!(fetched.len(), 2);
@@ -2945,6 +2992,40 @@ mod tests {
         let error = client
             .fetch_incremental("mailbox", 0, Some(feb_modseq))
             .expect_err("HTTP errors should fail archive fetch");
+        assert!(error.to_string().contains("HTTP 404"));
+
+        handle.join().expect("join HTTP server");
+    }
+
+    #[test]
+    fn gnu_archive_client_checks_status_before_reading_error_body() {
+        let feb_modseq =
+            parse_gnu_archive_listing_timestamp("2026-02-26", "09:12").expect("feb timestamp");
+        let index_body = r#"
+<pre>
+<a href="2026-02">2026-02</a> 2026-02-26 09:12  855K
+<a href="2026-03">2026-03</a> 2026-03-07 06:37  341K
+</pre>
+"#;
+        let (base_url, handle) = start_http_server_with_raw_responses(2, move |path| {
+            match path {
+            "/mailbox/" => format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n{}",
+                index_body.len(),
+                index_body,
+            )
+            .into_bytes(),
+            "/mailbox/2026-03" => b"HTTP/1.1 404 Not Found\r\nContent-Length: 64\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\nshort".to_vec(),
+            _ => panic!("unexpected HTTP path {path}"),
+        }
+        });
+
+        let mut client = GnuArchiveClient::new(Some(&base_url)).expect("create archive client");
+        client.connect().expect("connect archive");
+
+        let error = client
+            .fetch_incremental("mailbox", 0, Some(feb_modseq))
+            .expect_err("HTTP status should fail before reading body");
         assert!(error.to_string().contains("HTTP 404"));
 
         handle.join().expect("join HTTP server");

--- a/src/infra/mail_store.rs
+++ b/src/infra/mail_store.rs
@@ -1175,7 +1175,7 @@ mod tests {
 
     use super::{
         IncomingMail, SyncBatch, apply_sync_batch, load_mailbox_state, load_thread_rows_by_mailbox,
-        prune_mailbox_subjects,
+        mailbox_message_count, prune_mailbox_subjects, rebuild_all_threads,
     };
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -1198,6 +1198,275 @@ mod tests {
             raw_path: PathBuf::from(format!("/tmp/{mailbox}-{uid}.eml")),
             parsed: mail_parser::parse_headers(raw.as_bytes(), fallback_id),
         }
+    }
+
+    fn incoming_at_path(mailbox: &str, uid: u32, raw_path: PathBuf, raw: &str) -> IncomingMail {
+        let fallback_id = format!("synthetic-{mailbox}-{uid}@local");
+        IncomingMail {
+            mailbox: mailbox.to_string(),
+            uid,
+            modseq: Some(uid as u64),
+            flags: vec!["Seen".to_string()],
+            raw_path,
+            parsed: mail_parser::parse_headers(raw.as_bytes(), fallback_id),
+        }
+    }
+
+    fn empty_batch(mailbox: &str) -> SyncBatch {
+        SyncBatch {
+            mailbox: mailbox.to_string(),
+            uidvalidity: 1,
+            highest_uid: 0,
+            highest_modseq: None,
+            mails: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn mailbox_state_starts_empty_and_message_count_skips_expunged_rows() {
+        let root = temp_dir("mailbox-state");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let state = load_mailbox_state(&db_path, "inbox").expect("load initial state");
+        assert!(state.is_none());
+
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 2,
+            highest_modseq: Some(2),
+            mails: vec![
+                incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <keep@example.com>\nSubject: keep\nFrom: keep@example.com\n\nbody\n",
+                ),
+                incoming(
+                    "inbox",
+                    2,
+                    "Message-ID: <drop@example.com>\nSubject: drop\nFrom: drop@example.com\n\nbody\n",
+                ),
+            ],
+        };
+        apply_sync_batch(&db_path, batch).expect("seed mailbox");
+
+        let connection = Connection::open(&db_path).expect("open db");
+        connection
+            .execute(
+                "UPDATE mail SET is_expunged = 1 WHERE message_id = 'drop@example.com'",
+                [],
+            )
+            .expect("mark expunged");
+        drop(connection);
+
+        let count = mailbox_message_count(&db_path, "inbox").expect("count active mail");
+        assert_eq!(count, 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn empty_sync_batch_preserves_checkpoint_and_skips_thread_rebuild() {
+        let root = temp_dir("empty-batch");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let first_batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 5,
+            highest_modseq: Some(10),
+            mails: vec![incoming(
+                "inbox",
+                5,
+                "Message-ID: <seed@example.com>\nSubject: seed\nFrom: seed@example.com\n\nbody\n",
+            )],
+        };
+        apply_sync_batch(&db_path, first_batch).expect("first sync");
+
+        let second_batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 3,
+            highest_modseq: Some(8),
+            mails: Vec::new(),
+        };
+        let result = apply_sync_batch(&db_path, second_batch).expect("empty sync");
+
+        assert_eq!(result.inserted, 0);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.rebuilt_roots, 0);
+        assert!(!result.mailbox_rebuilt);
+        assert_eq!(result.state.last_seen_uid, 5);
+        assert_eq!(result.state.highest_modseq, Some(10));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn storage_functions_report_clear_errors_for_uninitialized_database() {
+        let root = temp_dir("uninitialized");
+        let db_path = root.join("criew.db");
+        Connection::open(&db_path).expect("create raw sqlite database");
+
+        let load_state_error = load_mailbox_state(&db_path, "inbox")
+            .expect_err("raw database should reject state lookup");
+        assert!(
+            load_state_error
+                .to_string()
+                .contains("failed to load mailbox checkpoint")
+        );
+
+        let count_error = mailbox_message_count(&db_path, "inbox")
+            .expect_err("raw database should reject message counts");
+        assert!(count_error.to_string().contains("failed to count mails"));
+
+        let prune_error = prune_mailbox_subjects(&db_path, "inbox", |_| true)
+            .expect_err("raw database should reject prune queries");
+        assert!(
+            prune_error
+                .to_string()
+                .contains("failed to prepare mailbox prune query")
+        );
+
+        let sync_error = apply_sync_batch(&db_path, empty_batch("inbox"))
+            .expect_err("raw database should reject sync writes");
+        assert!(
+            sync_error
+                .to_string()
+                .contains("failed to load mailbox checkpoint")
+        );
+
+        let rows_error = load_thread_rows_by_mailbox(&db_path, "inbox", 10)
+            .expect_err("raw database should reject thread row loads");
+        assert!(
+            rows_error
+                .to_string()
+                .contains("mailbox-specific thread query")
+        );
+
+        let rebuild_error =
+            rebuild_all_threads(&db_path).expect_err("raw database should reject thread rebuilds");
+        assert!(
+            rebuild_error
+                .to_string()
+                .contains("failed to prepare mail graph query")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn checkpoint_handles_missing_modseq_and_rejects_uidvalidity_overflow() {
+        let root = temp_dir("checkpoint-modseq");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let mut first_mail = incoming(
+            "inbox",
+            1,
+            "Message-ID: <root@example.com>\nSubject: root\nFrom: root@example.com\n\nbody\n",
+        );
+        first_mail.modseq = None;
+        let first = apply_sync_batch(
+            &db_path,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: None,
+                mails: vec![first_mail],
+            },
+        )
+        .expect("persist checkpoint without modseq");
+        assert_eq!(first.state.highest_modseq, None);
+
+        let second = apply_sync_batch(
+            &db_path,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: Some(7),
+                mails: Vec::new(),
+            },
+        )
+        .expect("adopt first modseq checkpoint");
+        assert_eq!(second.state.highest_modseq, Some(7));
+
+        let third = apply_sync_batch(
+            &db_path,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: None,
+                mails: Vec::new(),
+            },
+        )
+        .expect("preserve previous modseq checkpoint");
+        assert_eq!(third.state.highest_modseq, Some(7));
+
+        let overflow = apply_sync_batch(
+            &db_path,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: u64::MAX,
+                highest_uid: 1,
+                highest_modseq: Some(8),
+                mails: Vec::new(),
+            },
+        )
+        .expect_err("overflowing uidvalidity should fail");
+        assert!(overflow.to_string().contains("overflows i64 sqlite field"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn apply_sync_batch_reports_missing_checkpoint_after_trigger_removes_it() {
+        let root = temp_dir("checkpoint-trigger");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let connection = Connection::open(&db_path).expect("open db");
+        connection
+            .execute(
+                "
+CREATE TRIGGER delete_mailbox_checkpoint
+AFTER INSERT ON imap_mailbox_state
+BEGIN
+    DELETE FROM imap_mailbox_state WHERE mailbox = NEW.mailbox;
+END
+",
+                [],
+            )
+            .expect("create checkpoint trigger");
+        drop(connection);
+
+        let error = apply_sync_batch(
+            &db_path,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: Some(1),
+                mails: vec![incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <root@example.com>\nSubject: root\nFrom: root@example.com\n\nbody\n",
+                )],
+            },
+        )
+        .expect_err("missing checkpoint row should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("missing mailbox checkpoint after update")
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -1388,6 +1657,106 @@ mod tests {
     }
 
     #[test]
+    fn prune_mailbox_subjects_noop_keeps_rows_unchanged() {
+        let root = temp_dir("prune-noop");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 1,
+            highest_modseq: Some(1),
+            mails: vec![incoming(
+                "inbox",
+                1,
+                "Message-ID: <keep@example.com>\nSubject: [PATCH] keep\nFrom: keep@example.com\n\nbody\n",
+            )],
+        };
+        apply_sync_batch(&db_path, batch).expect("seed mailbox");
+
+        let pruned = prune_mailbox_subjects(&db_path, "inbox", |_| true).expect("noop prune");
+        assert_eq!(pruned, 0);
+        assert_eq!(
+            mailbox_message_count(&db_path, "inbox").expect("count mails"),
+            1
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prune_mailbox_subjects_tolerates_missing_raw_files() {
+        let root = temp_dir("prune-missing-raw");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let raw_path = root.join("status.eml");
+        fs::write(&raw_path, "raw mail").expect("write raw mail");
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 1,
+            highest_modseq: Some(1),
+            mails: vec![incoming_at_path(
+                "inbox",
+                1,
+                raw_path.clone(),
+                "Message-ID: <status@example.com>\nSubject: status\nFrom: status@example.com\n\nbody\n",
+            )],
+        };
+        apply_sync_batch(&db_path, batch).expect("seed mailbox");
+        fs::remove_file(&raw_path).expect("remove raw mail before prune");
+
+        let pruned =
+            prune_mailbox_subjects(&db_path, "inbox", |_| false).expect("prune missing raw file");
+        assert_eq!(pruned, 1);
+        assert_eq!(
+            mailbox_message_count(&db_path, "inbox").expect("count remaining mail"),
+            0
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prune_mailbox_subjects_keeps_database_progress_when_raw_cleanup_fails() {
+        let root = temp_dir("prune-raw-error");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let raw_dir = root.join("raw-dir");
+        fs::create_dir_all(&raw_dir).expect("create raw directory");
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 1,
+            highest_modseq: Some(1),
+            mails: vec![incoming_at_path(
+                "inbox",
+                1,
+                raw_dir.clone(),
+                "Message-ID: <status@example.com>\nSubject: status\nFrom: status@example.com\n\nbody\n",
+            )],
+        };
+        apply_sync_batch(&db_path, batch).expect("seed mailbox");
+
+        let pruned = prune_mailbox_subjects(&db_path, "inbox", |_| false)
+            .expect("cleanup failures should not roll back prune");
+        assert_eq!(pruned, 1);
+        assert_eq!(
+            mailbox_message_count(&db_path, "inbox").expect("count remaining mail"),
+            0
+        );
+        assert!(
+            raw_dir.exists(),
+            "raw cleanup failure should leave directory intact"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn threading_prefers_references_then_in_reply_to() {
         let root = temp_dir("threading");
         let db_path = root.join("criew.db");
@@ -1563,6 +1932,249 @@ WHERE m.message_id = 'grand@example.com'
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].message_id, "thread-a@example.com");
         assert_eq!(rows[1].message_id, "thread-b@example.com");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rebuild_all_threads_restores_materialized_rows_after_manual_deletion() {
+        let root = temp_dir("rebuild-all");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 2,
+            highest_modseq: Some(2),
+            mails: vec![
+                incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <root@example.com>\nSubject: root\nFrom: root@example.com\n\nbody\n",
+                ),
+                incoming(
+                    "inbox",
+                    2,
+                    "Message-ID: <reply@example.com>\nSubject: Re: root\nFrom: reply@example.com\nIn-Reply-To: <root@example.com>\nReferences: <root@example.com>\n\nbody\n",
+                ),
+            ],
+        };
+        apply_sync_batch(&db_path, batch).expect("seed mailbox");
+
+        let connection = Connection::open(&db_path).expect("open db");
+        connection
+            .execute("DELETE FROM thread_node", [])
+            .expect("clear thread nodes");
+        connection
+            .execute("DELETE FROM thread", [])
+            .expect("clear threads");
+        drop(connection);
+
+        let rebuilt = rebuild_all_threads(&db_path).expect("rebuild threads");
+        assert_eq!(rebuilt, 1);
+
+        let rows = load_thread_rows_by_mailbox(&db_path, "inbox", 20).expect("load rebuilt rows");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].message_id, "root@example.com");
+        assert_eq!(rows[1].message_id, "reply@example.com");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cyclic_references_degrade_to_a_stable_thread_shape() {
+        let root = temp_dir("cycle");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 2,
+            highest_modseq: Some(2),
+            mails: vec![
+                incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <a@example.com>\nSubject: loop a\nFrom: a@example.com\nIn-Reply-To: <b@example.com>\nReferences: <b@example.com>\n\nbody\n",
+                ),
+                incoming(
+                    "inbox",
+                    2,
+                    "Message-ID: <b@example.com>\nSubject: loop b\nFrom: b@example.com\nIn-Reply-To: <a@example.com>\nReferences: <a@example.com>\n\nbody\n",
+                ),
+            ],
+        };
+        apply_sync_batch(&db_path, batch).expect("sync cyclic thread");
+
+        let rows = load_thread_rows_by_mailbox(&db_path, "inbox", 20).expect("load thread rows");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].depth, 0);
+        assert_eq!(rows[1].depth, 1);
+        assert_eq!(rows[0].thread_id, rows[1].thread_id);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rebuild_all_threads_is_noop_for_an_empty_store() {
+        let root = temp_dir("rebuild-empty");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let rebuilt = rebuild_all_threads(&db_path).expect("rebuild empty store");
+        assert_eq!(rebuilt, 0);
+        assert!(
+            load_thread_rows_by_mailbox(&db_path, "inbox", 10)
+                .expect("load empty thread rows")
+                .is_empty()
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rebuild_all_threads_reports_corrupted_mail_ref_and_thread_node_tables() {
+        let root = temp_dir("rebuild-corruption");
+
+        let missing_ref_db = root.join("missing-ref.db");
+        db::initialize(&missing_ref_db).expect("initialize missing-ref db");
+        apply_sync_batch(
+            &missing_ref_db,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: Some(1),
+                mails: vec![incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <root@example.com>\nSubject: root\nFrom: root@example.com\n\nbody\n",
+                )],
+            },
+        )
+        .expect("seed missing-ref db");
+        let connection = Connection::open(&missing_ref_db).expect("open missing-ref db");
+        connection
+            .execute("DROP TABLE mail_ref", [])
+            .expect("drop mail_ref");
+        drop(connection);
+
+        let ref_error = rebuild_all_threads(&missing_ref_db)
+            .expect_err("missing mail_ref table should fail rebuild");
+        assert!(
+            ref_error
+                .to_string()
+                .contains("failed to prepare mail_ref graph query")
+        );
+
+        let missing_thread_node_db = root.join("missing-thread-node.db");
+        db::initialize(&missing_thread_node_db).expect("initialize missing-thread-node db");
+        apply_sync_batch(
+            &missing_thread_node_db,
+            SyncBatch {
+                mailbox: "inbox".to_string(),
+                uidvalidity: 1,
+                highest_uid: 1,
+                highest_modseq: Some(1),
+                mails: vec![incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <root2@example.com>\nSubject: root2\nFrom: root2@example.com\n\nbody\n",
+                )],
+            },
+        )
+        .expect("seed missing-thread-node db");
+        let connection =
+            Connection::open(&missing_thread_node_db).expect("open missing-thread-node db");
+        connection
+            .execute("DROP TABLE thread_node", [])
+            .expect("drop thread_node");
+        drop(connection);
+
+        let thread_node_error = rebuild_all_threads(&missing_thread_node_db)
+            .expect_err("missing thread_node table should fail rebuild");
+        assert!(
+            thread_node_error
+                .to_string()
+                .contains("failed to clear thread_node")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn late_arriving_parent_rethreads_existing_descendants() {
+        let root = temp_dir("late-parent");
+        let db_path = root.join("criew.db");
+        db::initialize(&db_path).expect("initialize db");
+
+        let orphan_batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 2,
+            highest_modseq: Some(2),
+            mails: vec![
+                incoming(
+                    "inbox",
+                    1,
+                    "Message-ID: <child@example.com>\nSubject: Re: root\nFrom: child@example.com\nIn-Reply-To: <root@example.com>\nReferences: <root@example.com>\n\nbody\n",
+                ),
+                incoming(
+                    "inbox",
+                    2,
+                    "Message-ID: <grand@example.com>\nSubject: Re: root\nFrom: grand@example.com\nIn-Reply-To: <child@example.com>\nReferences: <root@example.com> <child@example.com>\n\nbody\n",
+                ),
+            ],
+        };
+        apply_sync_batch(&db_path, orphan_batch).expect("sync orphaned descendants");
+
+        let orphan_rows =
+            load_thread_rows_by_mailbox(&db_path, "inbox", 20).expect("load orphaned rows");
+        assert_eq!(
+            orphan_rows
+                .iter()
+                .map(|row| (row.message_id.as_str(), row.depth))
+                .collect::<Vec<_>>(),
+            vec![("child@example.com", 0), ("grand@example.com", 1)]
+        );
+
+        let parent_batch = SyncBatch {
+            mailbox: "inbox".to_string(),
+            uidvalidity: 1,
+            highest_uid: 3,
+            highest_modseq: Some(3),
+            mails: vec![incoming(
+                "inbox",
+                3,
+                "Message-ID: <root@example.com>\nSubject: root\nFrom: root@example.com\n\nbody\n",
+            )],
+        };
+        let result = apply_sync_batch(&db_path, parent_batch).expect("sync late parent");
+        assert_eq!(result.inserted, 1);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.rebuilt_roots, 1);
+        assert!(!result.mailbox_rebuilt);
+
+        let rethreaded_rows =
+            load_thread_rows_by_mailbox(&db_path, "inbox", 20).expect("load rethreaded rows");
+        assert_eq!(
+            rethreaded_rows
+                .iter()
+                .map(|row| (row.message_id.as_str(), row.depth))
+                .collect::<Vec<_>>(),
+            vec![
+                ("root@example.com", 0),
+                ("child@example.com", 1),
+                ("grand@example.com", 2),
+            ]
+        );
+        assert!(
+            rethreaded_rows
+                .windows(2)
+                .all(|rows| rows[0].thread_id == rows[1].thread_id)
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/infra/sendmail.rs
+++ b/src/infra/sendmail.rs
@@ -15,6 +15,8 @@ use chrono::Utc;
 use crate::infra::config::RuntimeConfig;
 
 const DEFAULT_SEND_TIMEOUT: Duration = Duration::from_secs(60);
+const EXECUTABLE_BUSY_RETRY_ATTEMPTS: u8 = 5;
+const EXECUTABLE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
 const OUTBOX_DIR_NAME: &str = "reply-outbox";
 const GIT_SENDEMAIL_FROM_ARGS: &[&str] = &["config", "sendemail.from"];
 const GIT_USER_NAME_LOOKUP_ARGS: &[&str] = &["config", "user.name"];
@@ -181,6 +183,15 @@ fn send_with_command_path(
     request: &SendRequest,
     command_path: Option<&Path>,
 ) -> SendOutcome {
+    send_with_options(runtime, request, command_path, DEFAULT_SEND_TIMEOUT)
+}
+
+fn send_with_options(
+    runtime: &RuntimeConfig,
+    request: &SendRequest,
+    command_path: Option<&Path>,
+    timeout: Duration,
+) -> SendOutcome {
     let started_at = now_timestamp();
     let message_id = generate_message_id(&request.from);
     let draft_dir = runtime.data_dir.join(OUTBOX_DIR_NAME);
@@ -250,7 +261,7 @@ fn send_with_command_path(
         // surface as structured outcomes the UI can record and display.
         .env("GIT_TERMINAL_PROMPT", "0");
 
-    let mut child = match command.spawn() {
+    let mut child = match spawn_command_with_retry(&mut command) {
         Ok(child) => child,
         Err(error) => {
             return failed_outcome(
@@ -269,7 +280,7 @@ fn send_with_command_path(
         match child.try_wait() {
             Ok(Some(_)) => break,
             Ok(None) => {
-                if start.elapsed() >= DEFAULT_SEND_TIMEOUT {
+                if start.elapsed() >= timeout {
                     timed_out = true;
                     let _ = child.kill();
                     break;
@@ -317,7 +328,7 @@ fn send_with_command_path(
             stderr,
             error_summary: Some(format!(
                 "git send-email timed out after {}s",
-                DEFAULT_SEND_TIMEOUT.as_secs()
+                timeout.as_secs()
             )),
             started_at,
             finished_at,
@@ -358,6 +369,21 @@ fn send_with_command_path(
         started_at,
         finished_at,
         status: SendStatus::Failed,
+    }
+}
+
+fn spawn_command_with_retry(command: &mut Command) -> std::io::Result<std::process::Child> {
+    let mut attempts_remaining = EXECUTABLE_BUSY_RETRY_ATTEMPTS;
+
+    loop {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if is_retryable_executable_busy(&error) && attempts_remaining > 0 => {
+                attempts_remaining -= 1;
+                thread::sleep(EXECUTABLE_BUSY_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 
@@ -438,7 +464,7 @@ fn run_probe<T>(command: T, args: &[&str], display_path: &Path, command_text: St
 where
     T: AsRef<std::ffi::OsStr>,
 {
-    match Command::new(command).args(args).output() {
+    match output_with_retry(Command::new(command).args(args)) {
         Ok(output) if output.status.success() => Probe::Available {
             path: display_path.to_path_buf(),
             version: normalize_output(&output.stdout)
@@ -464,7 +490,7 @@ fn run_send_email_probe<T>(command: T, display_path: &Path, command_text: String
 where
     T: AsRef<std::ffi::OsStr> + Copy,
 {
-    match Command::new(command).args(["send-email", "-h"]).output() {
+    match output_with_retry(Command::new(command).args(["send-email", "-h"])) {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -509,7 +535,7 @@ fn probe_git_version<T>(command: T) -> Option<String>
 where
     T: AsRef<std::ffi::OsStr>,
 {
-    let output = Command::new(command).arg("--version").output().ok()?;
+    let output = output_with_retry(Command::new(command).arg("--version")).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -577,9 +603,7 @@ fn resolve_git_binary(
 }
 
 fn git_config_value(command: &str, args: &[&str]) -> std::result::Result<Option<String>, String> {
-    let output = Command::new(command)
-        .args(args)
-        .output()
+    let output = output_with_retry(Command::new(command).args(args))
         .map_err(|error| format!("failed to run git {}: {error}", args.join(" ")))?;
 
     if !output.status.success() {
@@ -596,6 +620,25 @@ fn git_config_value(command: &str, args: &[&str]) -> std::result::Result<Option<
     } else {
         Ok(Some(value))
     }
+}
+
+fn output_with_retry(command: &mut Command) -> std::io::Result<std::process::Output> {
+    let mut attempts_remaining = EXECUTABLE_BUSY_RETRY_ATTEMPTS;
+
+    loop {
+        match command.output() {
+            Ok(output) => return Ok(output),
+            Err(error) if is_retryable_executable_busy(&error) && attempts_remaining > 0 => {
+                attempts_remaining -= 1;
+                thread::sleep(EXECUTABLE_BUSY_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_retryable_executable_busy(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::ExecutableFileBusy
 }
 
 fn parse_identity(value: &str) -> Option<ParsedIdentity> {
@@ -632,10 +675,7 @@ fn extract_email_address(value: &str) -> Option<String> {
 fn normalize_message_id(value: &str) -> String {
     value
         .trim()
-        .trim_matches('<')
-        .trim_matches('>')
-        .trim_matches('"')
-        .trim_matches(',')
+        .trim_matches(|character| matches!(character, '<' | '>' | '"' | ','))
         .trim()
         .to_string()
 }
@@ -793,6 +833,7 @@ fn now_timestamp() -> String {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -800,8 +841,10 @@ mod tests {
     use crate::infra::config::RuntimeConfig;
 
     use super::{
-        GitSendEmailStatus, SendRequest, SendStatus, check_with_command_path,
-        resolve_reply_identity_with_command_path, send_with_command_path,
+        GitSendEmailStatus, ReplyIdentitySource, SendRequest, SendStatus, check_with_command_path,
+        extract_email_address, generate_message_id, normalize_message_id, normalize_output,
+        render_command_line, render_message_file, resolve_reply_identity_with_command_path,
+        resolve_working_dir, send_with_command_path, send_with_options, summarize_failure,
     };
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -809,7 +852,10 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("criew-sendmail-{label}-{nonce}"));
+        let path = std::env::temp_dir().join(format!(
+            "criew-sendmail-{label}-{}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&path).expect("create temp dir");
         path
     }
@@ -837,10 +883,19 @@ mod tests {
 
     fn write_fake_git(root: &Path, body: &str) -> PathBuf {
         let path = root.join("fake-git.sh");
-        fs::write(&path, body).expect("write fake git");
-        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        let staging_path = root.join(".fake-git.sh.tmp");
+        let mut staging_file = fs::File::create(&staging_path).expect("create staging fake git");
+        staging_file
+            .write_all(body.as_bytes())
+            .expect("write staging fake git");
+        staging_file.sync_all().expect("sync staging fake git");
+        drop(staging_file);
+        let mut permissions = fs::metadata(&staging_path)
+            .expect("staging metadata")
+            .permissions();
         permissions.set_mode(0o755);
-        fs::set_permissions(&path, permissions).expect("chmod");
+        fs::set_permissions(&staging_path, permissions).expect("chmod");
+        fs::rename(&staging_path, &path).expect("install fake git");
         path
     }
 
@@ -914,6 +969,63 @@ mod tests {
     }
 
     #[test]
+    fn check_reports_broken_and_missing_send_email() {
+        let root = temp_dir("check-broken");
+        let fake_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'fatal: send-email support missing' >&2\n  exit 1\nfi\nexit 1\n",
+        );
+
+        match check_with_command_path(Some(&fake_git)).status {
+            GitSendEmailStatus::Broken { reason, .. } => {
+                assert_eq!(reason, "fatal: send-email support missing");
+            }
+            other => panic!("unexpected status: {other:?}"),
+        }
+
+        match check_with_command_path(Some(&root.join("missing-git"))).status {
+            GitSendEmailStatus::Missing => {}
+            other => panic!("unexpected status: {other:?}"),
+        }
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolve_identity_falls_back_to_user_name_email_and_reports_errors() {
+        let root = temp_dir("identity-fallback");
+        let fallback_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"sendemail.from\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"user.email\" ]; then\n  echo 'fallback@example.com'\n  exit 0\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"user.name\" ]; then\n  echo '   '\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let identity = resolve_reply_identity_with_command_path(Some(&fallback_git))
+            .expect("resolve fallback identity");
+        assert_eq!(identity.display, "fallback@example.com");
+        assert_eq!(identity.email, "fallback@example.com");
+        assert_eq!(identity.source, ReplyIdentitySource::UserNameEmail);
+        assert_eq!(identity.source.as_str(), "git config user.name/user.email");
+
+        let invalid_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"sendemail.from\" ]; then\n  echo 'No Email Here'\n  exit 0\nfi\nexit 1\n",
+        );
+        let invalid = resolve_reply_identity_with_command_path(Some(&invalid_git))
+            .expect_err("invalid sendemail.from should fail");
+        assert!(invalid.contains("does not contain a valid email address"));
+
+        let missing_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"sendemail.from\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"user.email\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"user.name\" ]; then\n  exit 1\nfi\nexit 1\n",
+        );
+        let missing = resolve_reply_identity_with_command_path(Some(&missing_git))
+            .expect_err("missing user email should fail");
+        assert!(missing.contains("git email identity missing"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn send_success_removes_draft_and_keeps_generated_message_id() {
         let root = temp_dir("send-success");
         let capture = root.join("captured.eml");
@@ -978,6 +1090,118 @@ mod tests {
     }
 
     #[test]
+    fn send_reports_unavailable_transport_without_creating_draft() {
+        let root = temp_dir("send-unavailable");
+        let fake_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'fatal: send-email support missing' >&2\n  exit 1\nfi\nexit 1\n",
+        );
+        let runtime = test_runtime_in(&root);
+
+        let outcome = send_with_command_path(&runtime, &sample_request(), Some(&fake_git));
+
+        assert_eq!(outcome.status, SendStatus::Failed);
+        assert!(outcome.command_line.is_none());
+        assert!(outcome.draft_path.is_none());
+        assert!(
+            outcome
+                .error_summary
+                .as_deref()
+                .is_some_and(|summary| summary.contains("git send-email unavailable"))
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn send_failure_uses_stdout_or_exit_code_when_stderr_is_empty() {
+        let root = temp_dir("send-summary-fallbacks");
+        let stdout_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'usage: git send-email [<options>] <file|directory>...'\n  exit 129\nfi\nif [ \"$1\" = \"send-email\" ]; then\n  echo 'smtp failed on stdout'\n  exit 2\nfi\nexit 1\n",
+        );
+        let runtime = test_runtime_in(&root);
+        let stdout_outcome = send_with_command_path(&runtime, &sample_request(), Some(&stdout_git));
+        assert_eq!(stdout_outcome.status, SendStatus::Failed);
+        assert_eq!(
+            stdout_outcome.error_summary.as_deref(),
+            Some("smtp failed on stdout")
+        );
+
+        let exit_code_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'usage: git send-email [<options>] <file|directory>...'\n  exit 129\nfi\nif [ \"$1\" = \"send-email\" ]; then\n  exit 7\nfi\nexit 1\n",
+        );
+        let exit_code_outcome =
+            send_with_command_path(&runtime, &sample_request(), Some(&exit_code_git));
+        assert_eq!(exit_code_outcome.status, SendStatus::Failed);
+        assert_eq!(
+            exit_code_outcome.error_summary.as_deref(),
+            Some("git send-email exited with 7")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn send_times_out_and_keeps_draft_for_retry() {
+        let root = temp_dir("send-timeout");
+        let fake_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'usage: git send-email [<options>] <file|directory>...'\n  exit 129\nfi\nif [ \"$1\" = \"send-email\" ]; then\n  sleep 1\n  exit 0\nfi\nexit 1\n",
+        );
+        let runtime = test_runtime_in(&root);
+
+        let outcome = send_with_options(
+            &runtime,
+            &sample_request(),
+            Some(&fake_git),
+            std::time::Duration::from_millis(50),
+        );
+
+        assert_eq!(outcome.status, SendStatus::TimedOut);
+        assert!(outcome.timed_out);
+        assert!(
+            outcome
+                .draft_path
+                .as_ref()
+                .is_some_and(|path| path.exists())
+        );
+        assert_eq!(
+            outcome.error_summary.as_deref(),
+            Some("git send-email timed out after 0s")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn send_reports_outbox_creation_failure() {
+        let root = temp_dir("send-outbox-fail");
+        let data_file = root.join("blocked-data");
+        fs::write(&data_file, "not a directory").expect("write blocking data file");
+        let fake_git = write_fake_git(
+            &root,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'git version 2.51.0'\n  exit 0\nfi\nif [ \"$1\" = \"send-email\" ] && [ \"$2\" = \"-h\" ]; then\n  echo 'usage: git send-email [<options>] <file|directory>...'\n  exit 129\nfi\nexit 1\n",
+        );
+        let mut runtime = test_runtime_in(&root);
+        runtime.data_dir = data_file;
+
+        let outcome = send_with_command_path(&runtime, &sample_request(), Some(&fake_git));
+
+        assert_eq!(outcome.status, SendStatus::Failed);
+        assert!(outcome.draft_path.is_none());
+        assert!(
+            outcome
+                .error_summary
+                .as_deref()
+                .is_some_and(|summary| summary.contains("failed to create reply outbox"))
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn send_prefers_configured_kernel_tree_as_working_dir() {
         let root = temp_dir("send-working-dir");
         let kernel_tree = root.join("linux");
@@ -1000,6 +1224,69 @@ mod tests {
         let invoked_pwd = fs::read_to_string(&capture_pwd).expect("read captured pwd");
         assert_eq!(PathBuf::from(invoked_pwd.trim()), kernel_tree);
         assert_ne!(PathBuf::from(invoked_pwd.trim()), current_dir);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn message_rendering_and_helper_outputs_follow_reply_contract() {
+        let mut request = sample_request();
+        request.cc.clear();
+        request.references = vec![
+            "<older@example.com>,".to_string(),
+            "patch@example.com".to_string(),
+        ];
+
+        let rendered = render_message_file(&request, "generated@example.com");
+        assert!(rendered.contains("From: CRIEW Test <criew@example.com>"));
+        assert!(rendered.contains("To: maintainer@example.com"));
+        assert!(!rendered.contains("\nCc: "));
+        assert!(rendered.contains("Message-ID: <generated@example.com>"));
+        assert!(rendered.contains("In-Reply-To: <patch@example.com>"));
+        assert!(rendered.contains("References: <older@example.com> <patch@example.com>"));
+        assert!(rendered.ends_with("reply body\n"));
+
+        assert_eq!(
+            render_command_line(
+                "git send-email",
+                &[
+                    "--from".to_string(),
+                    "CRIEW Test <criew@example.com>".to_string(),
+                    String::new(),
+                ]
+            ),
+            "'git send-email' --from 'CRIEW Test <criew@example.com>' ''"
+        );
+        assert_eq!(
+            normalize_output(b"\n first line \nsecond\n"),
+            Some("first line".to_string())
+        );
+        assert_eq!(
+            summarize_failure(Some(9), "", ""),
+            Some("git send-email exited with 9".to_string())
+        );
+        assert_eq!(
+            normalize_message_id(" <older@example.com>, "),
+            "older@example.com"
+        );
+        assert_eq!(
+            extract_email_address("CRIEW Test <criew@example.com>"),
+            Some("criew@example.com".to_string())
+        );
+        assert_eq!(extract_email_address("invalid identity"), None);
+        assert!(generate_message_id("No Email").ends_with("@localhost"));
+    }
+
+    #[test]
+    fn resolve_working_dir_falls_back_when_kernel_tree_is_missing() {
+        let root = temp_dir("send-working-dir-fallback");
+        let runtime = test_runtime_in(&root);
+        let current_dir = std::env::current_dir().expect("current dir");
+        assert_eq!(resolve_working_dir(&runtime), current_dir);
+
+        let mut with_invalid_tree = test_runtime_in(&root);
+        with_invalid_tree.kernel_trees = vec![root.join("missing-tree")];
+        assert_eq!(resolve_working_dir(&with_invalid_tree), current_dir);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/ui/tui/reply.rs
+++ b/src/ui/tui/reply.rs
@@ -469,10 +469,7 @@ where
 fn normalize_message_id(value: &str) -> String {
     value
         .trim()
-        .trim_matches('<')
-        .trim_matches('>')
-        .trim_matches('"')
-        .trim_matches(',')
+        .trim_matches(|character| matches!(character, '<' | '>' | '"' | ','))
         .trim()
         .to_string()
 }
@@ -622,7 +619,7 @@ mod tests {
 
     use super::{
         ReplyIdentity, ReplyPreviewRequest, build_reply_seed, extract_email_address,
-        normalize_reply_subject, render_reply_preview,
+        normalize_reply_subject, prepare_reply_message, render_reply_preview,
     };
 
     fn sample_thread(subject: &str, message_id: &str) -> ThreadRow {
@@ -704,6 +701,100 @@ mod tests {
     }
 
     #[test]
+    fn build_reply_seed_falls_back_to_thread_metadata_and_empty_body() {
+        let raw = b"Message-ID: <patch@example.com>\r\n\r\n";
+        let mut thread = sample_thread("[PATCH] fallback", "thread@example.com");
+        thread.from_addr = "Thread Author <author@example.com>".to_string();
+        thread.date = Some("Sat, 7 Mar 2026 12:00:00 +0000".to_string());
+
+        let seed = build_reply_seed(raw, &thread, &identity(), &[identity().email.clone()]);
+
+        assert_eq!(seed.to, "Thread Author <author@example.com>");
+        assert!(seed.cc.is_empty());
+        assert_eq!(seed.subject, "Re: [PATCH] fallback");
+        assert_eq!(seed.in_reply_to, "patch@example.com");
+        assert_eq!(seed.references, vec!["patch@example.com"]);
+        assert_eq!(
+            seed.body[1],
+            "On Sat, 7 Mar 2026 12:00:00 +0000, Thread Author <author@example.com> wrote:"
+        );
+        assert_eq!(seed.body[2], "> <empty mail body>");
+    }
+
+    #[test]
+    fn build_reply_seed_handles_folded_headers_and_blank_body_lines() {
+        let raw = b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] folded\r\nFrom: Alice <alice@example.com>\r\nTo: \"Doe, Jane\" <jane@example.com>,\r\n Bob <bob@example.com>\r\nCc: Carol <carol@example.com>;\r\n\tCRIEW Test <criew@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nline one\r\n\r\nline two\r\n";
+        let thread = sample_thread("[PATCH] folded", "patch@example.com");
+
+        let seed = build_reply_seed(raw, &thread, &identity(), &[identity().email.clone()]);
+
+        assert_eq!(
+            seed.to,
+            "\"Doe, Jane\" <jane@example.com>, Bob <bob@example.com>"
+        );
+        assert_eq!(seed.cc, "Carol <carol@example.com>");
+        assert_eq!(seed.body[2], "> line one");
+        assert_eq!(seed.body[3], ">");
+        assert_eq!(seed.body[4], "> line two");
+    }
+
+    #[test]
+    fn prepare_reply_message_uses_parent_when_references_missing() {
+        let (message, errors) = prepare_reply_message(ReplyPreviewRequest {
+            from: "CRIEW Test <criew@example.com>",
+            to: "Bob <bob@example.com>",
+            cc: "",
+            subject: "[PATCH] demo",
+            in_reply_to: " <parent@example.com>, ",
+            references: &[],
+            body: &[
+                "line one   ".to_string(),
+                String::new(),
+                "line two".to_string(),
+            ],
+            self_addresses: &[identity().email.clone()],
+        });
+
+        assert!(errors.is_empty());
+        assert_eq!(message.subject, "Re: [PATCH] demo");
+        assert_eq!(message.in_reply_to, "parent@example.com");
+        assert_eq!(message.references, vec!["parent@example.com"]);
+        assert_eq!(message.body, "line one\n\nline two");
+    }
+
+    #[test]
+    fn prepare_reply_message_adds_parent_to_existing_references_and_filters_self() {
+        let (message, errors) = prepare_reply_message(ReplyPreviewRequest {
+            from: " CRIEW Test <criew@example.com> ",
+            to: "Bob <bob@example.com>; \"Doe, Jane\" <jane@example.com>; CRIEW Test <criew@example.com>",
+            cc: "Carol <carol@example.com>, criew@example.com",
+            subject: "fwd: [PATCH] demo",
+            in_reply_to: " <parent@example.com>, ",
+            references: &["<older@example.com>".to_string()],
+            body: &["body".to_string()],
+            self_addresses: &[identity().email.clone(), "alias@example.com".to_string()],
+        });
+
+        assert!(errors.is_empty());
+        assert_eq!(
+            message.to,
+            vec![
+                "Bob <bob@example.com>".to_string(),
+                "\"Doe, Jane\" <jane@example.com>".to_string()
+            ]
+        );
+        assert_eq!(message.cc, vec!["Carol <carol@example.com>".to_string()]);
+        assert_eq!(message.subject, "Re: [PATCH] demo");
+        assert_eq!(
+            message.references,
+            vec![
+                "older@example.com".to_string(),
+                "parent@example.com".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn preview_validation_reports_missing_recipients() {
         let preview = render_reply_preview(ReplyPreviewRequest {
             from: "CRIEW Test <criew@example.com>",
@@ -748,6 +839,51 @@ mod tests {
     }
 
     #[test]
+    fn render_reply_preview_reports_missing_headers_and_renders_placeholders() {
+        let preview = render_reply_preview(ReplyPreviewRequest {
+            from: "CRIEW Test",
+            to: "",
+            cc: "",
+            subject: "   ",
+            in_reply_to: "   ",
+            references: &[],
+            body: &["   ".to_string(), String::new()],
+            self_addresses: &[],
+        });
+
+        assert!(
+            preview
+                .errors
+                .iter()
+                .any(|value| value == "From is missing a valid email address")
+        );
+        assert!(
+            preview
+                .errors
+                .iter()
+                .any(|value| value == "reply preview has no recipients after removing self")
+        );
+        assert!(
+            preview
+                .errors
+                .iter()
+                .any(|value| value == "Subject is empty")
+        );
+        assert!(
+            preview
+                .errors
+                .iter()
+                .any(|value| value == "In-Reply-To is missing")
+        );
+        assert!(preview.content.contains("To: <none>"));
+        assert!(preview.content.contains("Cc: <none>"));
+        assert!(preview.content.contains("Subject: Re:"));
+        assert!(preview.content.contains("In-Reply-To: <none>"));
+        assert!(preview.content.contains("References: <none>"));
+        assert!(preview.content.ends_with("<empty body>"));
+    }
+
+    #[test]
     fn extracts_email_from_display_or_bare_value() {
         assert_eq!(
             extract_email_address("Alice <alice@example.com>"),
@@ -757,5 +893,7 @@ mod tests {
             extract_email_address("alice@example.com"),
             Some("alice@example.com".to_string())
         );
+        assert_eq!(extract_email_address("Alice Example"), None);
+        assert_eq!(extract_email_address("<>"), None);
     }
 }

--- a/src/ui/tui/tests.rs
+++ b/src/ui/tui/tests.rs
@@ -454,6 +454,15 @@ fn mailbox_sync_spawner_stub(
     receiver
 }
 
+fn type_text(state: &mut AppState, text: &str) {
+    for character in text.chars() {
+        let _ = handle_key_event(
+            state,
+            KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE),
+        );
+    }
+}
+
 #[test]
 fn empty_query_returns_all_palette_commands() {
     let all = matching_commands("");
@@ -1107,6 +1116,140 @@ inbox_auto_sync_interval_secs = 30
     assert!(persisted.contains("inbox_auto_sync_interval_secs = 30"));
 
     let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn config_editor_reports_unsupported_key_hint_and_allows_keyboard_navigation() {
+    let mut state = AppState::new(vec![], test_runtime());
+
+    state.open_config_editor(Some("unsupported.key"));
+
+    assert!(state.config_editor.open);
+    assert!(
+        state
+            .status
+            .contains("config editor does not support unsupported.key")
+    );
+    assert_eq!(state.selected_config_editor_field().key, "source.mailbox");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    assert_ne!(state.selected_config_editor_field().key, "source.mailbox");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+    assert_eq!(state.selected_config_editor_field().key, "source.mailbox");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert!(!state.config_editor.open);
+    assert_eq!(state.status, "config editor closed");
+}
+
+#[test]
+fn config_editor_edit_mode_handles_char_backspace_tab_and_escape() {
+    let root = temp_dir("config-editor-keyboard");
+    let config_path = root.join("criew-config.toml");
+    fs::write(
+        &config_path,
+        r#"
+[ui]
+startup_sync = true
+"#,
+    )
+    .expect("write config file");
+
+    let mut runtime = test_runtime();
+    runtime.config_path = config_path;
+    let mut state = AppState::new(vec![], runtime);
+
+    state.open_config_editor(Some("ui.startup_sync"));
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(matches!(
+        state.config_editor.mode,
+        super::ConfigEditorMode::Edit
+    ));
+    assert_eq!(state.config_editor.input, "true");
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+    );
+    assert_eq!(state.config_editor.input, "truex");
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert_eq!(state.config_editor.input, "true");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert_eq!(state.config_editor.input, "false");
+    assert_eq!(state.status, "preset value selected for ui.startup_sync");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert!(matches!(
+        state.config_editor.mode,
+        super::ConfigEditorMode::Browse
+    ));
+    assert!(state.config_editor.input.is_empty());
+    assert_eq!(state.status, "config edit cancelled");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn config_palette_help_and_usage_are_reported() {
+    let mut state = AppState::new(vec![], test_runtime());
+
+    state.palette.open = true;
+    state.palette.input = "config help".to_string();
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(state.status.contains("config usage:"));
+
+    state.palette.open = true;
+    state.palette.input = "config get".to_string();
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert_eq!(state.status, "usage: config get <key>");
+
+    state.palette.open = true;
+    state.palette.input = "config set".to_string();
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert_eq!(state.status, "usage: config set <key> <value>");
+}
+
+#[test]
+fn config_palette_reports_effective_and_missing_values() {
+    let mut state = AppState::new(vec![], test_runtime());
+
+    state.palette.open = true;
+    state.palette.input = "config get source.mailbox".to_string();
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(
+        state
+            .status
+            .contains("config effective source.mailbox = inbox (default/runtime)")
+    );
+
+    state.palette.open = true;
+    state.palette.input = "config get no.such.key".to_string();
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert_eq!(state.status, "config key not found: no.such.key");
 }
 
 #[test]
@@ -2630,6 +2773,183 @@ fn slash_opens_search_and_filters_threads() {
 }
 
 #[test]
+fn search_on_code_browser_reports_mail_only_scope() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.ui_page = UiPage::CodeBrowser;
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert!(!state.search.active);
+    assert_eq!(state.status, "search is only available on mail page");
+}
+
+#[test]
+fn search_backspace_and_escape_clear_pending_query() {
+    let mut state = AppState::new(vec![], test_runtime());
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+    );
+    type_text(&mut state, "ab");
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert_eq!(state.search.input, "a");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(!state.search.active);
+    assert!(state.search.input.is_empty());
+    assert_eq!(state.status, "search cancelled");
+}
+
+#[test]
+fn ctrl_backtick_closes_open_palette() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.palette.open = true;
+    state.palette.input = "help".to_string();
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('`'), KeyModifiers::CONTROL),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert!(!state.palette.open);
+    assert!(state.palette.input.is_empty());
+    assert_eq!(state.status, "command palette closed");
+}
+
+#[test]
+fn palette_reports_empty_and_unknown_commands() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.palette.open = true;
+    state.palette.input = "   ".to_string();
+
+    let empty_action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(matches!(empty_action, LoopAction::Continue));
+    assert_eq!(state.status, "empty command");
+
+    state.palette.open = true;
+    state.palette.input = "wat".to_string();
+    let unknown_action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(matches!(unknown_action, LoopAction::Continue));
+    assert_eq!(state.status, "unknown command: wat");
+}
+
+#[test]
+fn palette_escape_backspace_and_char_input_update_buffer() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.palette.open = true;
+    state.palette.input = "he".to_string();
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert_eq!(state.palette.input, "h");
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+    );
+    assert_eq!(state.palette.input, "hi");
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert!(!state.palette.open);
+    assert!(state.palette.input.is_empty());
+}
+
+#[test]
+fn palette_sync_command_runs_via_handle_key_event() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.sync_request_executor = sync_request_mock_success;
+    state.palette.open = true;
+    state.palette.input = "sync io-uring".to_string();
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert!(state.status.contains("sync ok"));
+}
+
+#[test]
+fn palette_bang_reports_empty_local_command() {
+    let mut state = AppState::new(vec![], test_runtime());
+    state.palette.open = true;
+    state.palette.input = "!   ".to_string();
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert_eq!(state.status, "empty local command after !");
+}
+
+#[test]
+fn enter_on_thread_sets_selected_status_message() {
+    let mut state = AppState::new(
+        vec![sample_thread("normal mail", "plain@example.com", 0)],
+        test_runtime(),
+    );
+    state.focus = Pane::Threads;
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert_eq!(state.status, "selected plain@example.com");
+}
+
+#[test]
+fn escape_quit_and_ctrl_c_show_exit_guidance() {
+    let mut state = AppState::new(vec![], test_runtime());
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    assert_eq!(
+        state.status,
+        "open command palette with : (preferred) or Ctrl+`"
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+    );
+    assert_eq!(
+        state.status,
+        "q emergency exit disabled; use command palette quit/exit"
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+    );
+    assert_eq!(
+        state.status,
+        "Ctrl+C is disabled, use command palette quit/exit"
+    );
+}
+
+#[test]
 fn jl_focus_and_ik_move_selection() {
     let mut state = AppState::new(
         vec![
@@ -3316,6 +3636,554 @@ fn reply_send_preview_uses_edited_header_values() {
         panel
             .preview_rendered
             .contains("Cc: List <list@example.com>")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn mail_page_r_opens_reply_panel_from_threads_focus() {
+    let root = temp_dir("reply-open-r");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Threads;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+    );
+
+    assert!(matches!(action, LoopAction::Continue));
+    assert!(state.reply_panel.is_some());
+    assert!(
+        state
+            .status
+            .contains("reply panel opened for <patch@example.com>")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_notice_escape_closes_blocked_notice() {
+    let root = temp_dir("reply-notice-esc");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+    );
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .and_then(|panel| panel.reply_notice.as_ref())
+            .is_some()
+    );
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| panel.reply_notice.is_none())
+    );
+    assert_eq!(state.status, "reply notice closed");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_send_preview_scrolls_with_j_and_k() {
+    let root = temp_dir("reply-preview-scroll");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+    );
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| panel.preview_open)
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+    );
+    assert_eq!(
+        state
+            .reply_panel
+            .as_ref()
+            .expect("reply panel")
+            .preview_scroll,
+        1
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+    );
+    assert_eq!(
+        state
+            .reply_panel
+            .as_ref()
+            .expect("reply panel")
+            .preview_scroll,
+        0
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_send_preview_escape_closes_preview() {
+    let root = temp_dir("reply-preview-esc");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| !panel.preview_open)
+    );
+    assert_eq!(state.status, "send preview closed");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_notice_enter_closes_blocked_notice() {
+    let root = temp_dir("reply-notice-enter");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| panel.reply_notice.is_none())
+    );
+    assert_eq!(state.status, "reply notice closed");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_command_mode_handles_empty_unsupported_and_discard_commands() {
+    let root = temp_dir("reply-command-mode");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert_eq!(state.status, "empty command");
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut state, "zzz");
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert_eq!(state.status, "unsupported command: :zzz");
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut state, "q!");
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(state.reply_panel.is_none());
+    assert_eq!(state.status, "discarded reply draft");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_command_mode_escape_and_backspace_restore_normal_mode() {
+    let root = temp_dir("reply-command-cancel");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut state, "ab");
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert_eq!(
+        state
+            .reply_panel
+            .as_ref()
+            .expect("reply panel")
+            .command_input,
+        "a"
+    );
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    let panel = state.reply_panel.as_ref().expect("reply panel");
+    assert!(matches!(panel.mode, ReplyEditMode::Normal));
+    assert!(panel.command_input.is_empty());
+    assert_eq!(state.status, "reply command cancelled");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_command_q_closes_clean_panel_but_blocks_dirty_draft() {
+    let root = temp_dir("reply-command-q");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut clean_state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    clean_state.focus = Pane::Preview;
+    clean_state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut clean_state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut clean_state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut clean_state, "q");
+    let _ = handle_key_event(
+        &mut clean_state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(clean_state.reply_panel.is_none());
+    assert_eq!(clean_state.status, "closed reply panel");
+
+    let mut dirty_state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    dirty_state.focus = Pane::Preview;
+    dirty_state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut dirty_state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    if let Some(panel) = dirty_state.reply_panel.as_mut() {
+        panel.mark_dirty();
+    }
+    let _ = handle_key_event(
+        &mut dirty_state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut dirty_state, "q");
+    let _ = handle_key_event(
+        &mut dirty_state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(dirty_state.reply_panel.is_some());
+    assert_eq!(
+        dirty_state.status,
+        "unsaved reply draft, run :q! to discard"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_command_preview_and_preview_enter_cover_remaining_preview_shortcuts() {
+    let root = temp_dir("reply-command-preview");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE),
+    );
+    type_text(&mut state, "preview");
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| panel.preview_open)
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+    );
+    assert!(
+        state
+            .reply_panel
+            .as_ref()
+            .is_some_and(|panel| panel.preview_confirmed)
+    );
+    assert_eq!(state.status, "send preview confirmed; ready to send");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reply_insert_mode_tab_and_backspace_modify_body() {
+    let root = temp_dir("reply-insert-tab");
+    let raw = root.join("patch.eml");
+    fs::write(
+        &raw,
+        b"Message-ID: <patch@example.com>\r\nSubject: [PATCH] demo\r\nFrom: Alice <alice@example.com>\r\nTo: Bob <bob@example.com>\r\nDate: Fri, 6 Mar 2026 09:30:00 +0000\r\n\r\nbody line\r\n",
+    )
+    .expect("write raw reply fixture");
+
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "[PATCH] demo",
+            "patch@example.com",
+            0,
+            raw.clone(),
+        )],
+        test_runtime(),
+    );
+    state.focus = Pane::Preview;
+    state.reply_identity_resolver = reply_identity_mock;
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
+    );
+    if let Some(panel) = state.reply_panel.as_mut() {
+        panel.section = ReplySection::Body;
+        panel.body = vec![String::new()];
+        panel.body_row = 0;
+        panel.cursor_col = 0;
+        panel.adjust_scroll();
+    }
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert_eq!(
+        state.reply_panel.as_ref().expect("reply panel").body[0],
+        "    "
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert_eq!(
+        state.reply_panel.as_ref().expect("reply panel").body[0],
+        "   "
     );
 
     let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary

- add IMAP doctor probing and archive sync behavior covered by the new tests
- extend patch, sendmail, and TUI regression coverage across mailbox workflows
- harden temporary command execution against transient executable-busy failures

## Related Issues

Link issues if applicable.

- Closes #
- Related to #

## What Changed

- Added doctor and sync-path coverage for IMAP configuration handling, connection probing, and summary/report rendering.
- Expanded lore.kernel.org and GNU archive sync support with tests for incremental fetches, feed/index parsing, raw mail retrieval, and proxy or transport failures.
- Strengthened patch workflow coverage around series indexing, apply/download persistence, conflict reporting, and no-op apply detection.
- Extended reply and TUI regression coverage for command palette behavior, search interactions, reply editing and preview flows, and mailbox navigation state transitions.
- Hardened temporary command execution in `b4` and `git send-email` paths by tolerating transient `ExecutableFileBusy` failures and stabilizing test fixture scripts.

## Testing

List what you ran locally.

```text
test result: ok. 298 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.18s
```

## Documentation

- [ ] No documentation change needed
- [ ] README updated
- [ ] Config / workflow docs updated
- [x] Other docs updated

## Checklist

- [x] The change is focused on one topic
- [x] Commit messages follow the repository convention
- [x] Tests were added or updated when needed
- [x] User-visible behavior was documented when needed
- [x] I checked for regressions in related workflows

## Notes For Reviewers

Anything that needs special attention during review.
