### PR TITLE
Improve interaction logic, panne switch, add keymap 

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -197,6 +197,7 @@ criew tui
 #### 键位
 
 - `:` 打开命令栏
+- 顶部状态栏会显示当前 keymap 方案：`default`、`vim` 或 `custom`
 - `y` / `n` 启用或禁用当前订阅
 - `Enter` 打开当前 mailbox 或 thread
 - `a` apply 当前 patch series

--- a/README-zh.md
+++ b/README-zh.md
@@ -205,6 +205,7 @@ criew tui
 - `u` 撤销本次会话中最近一次成功 apply
 - `r` 或 `e` 打开回信面板
 - `Tab` 在 Mail 页面和 Code Browser 页面之间切换
+- 当 `ui.keymap = "vim"` 时，`gg` 跳到当前 pane 行首，`G` 跳到行尾，`qq` 快速退出
 
 #### 命令栏命令
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -199,7 +199,7 @@ criew tui
 - `:` 打开命令栏
 - 顶部状态栏会显示当前 keymap 方案：`default`、`vim` 或 `custom`
 - `y` / `n` 启用或禁用当前订阅
-- `Enter` 打开当前 mailbox 或 thread
+- `Enter` 打开当前 mailbox 或 thread，并自动切到 threads 或 preview pane
 - `a` apply 当前 patch series
 - `d` 导出当前 patch series
 - `u` 撤销本次会话中最近一次成功 apply

--- a/README-zh.md
+++ b/README-zh.md
@@ -198,6 +198,7 @@ criew tui
 
 - `:` 打开命令栏
 - 顶部状态栏会显示当前 keymap 方案：`default`、`vim` 或 `custom`
+- 数字前缀可重复垂直移动：`default/custom` 使用 `数字 + i/k`，`vim` 使用 `数字 + j/k`
 - `y` / `n` 启用或禁用当前订阅
 - `Enter` 打开当前 mailbox 或 thread，并自动切到 threads 或 preview pane
 - `a` apply 当前 patch series

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Inside the TUI:
 - `:` opens the command palette
 - the header shows the active keymap scheme (`default`, `vim`, or `custom`)
 - `y` / `n` enable or disable the selected subscription
-- `Enter` opens the selected mailbox or thread
+- `Enter` opens the selected mailbox or thread and moves focus to threads or preview
 - `a` applies the current patch series
 - `d` exports the current patch series
 - `u` undoes the most recent successful apply from the current session

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Inside the TUI:
 - `u` undoes the most recent successful apply from the current session
 - `r` or `e` opens the reply panel
 - `Tab` switches between the mail page and the code browser
+- with `ui.keymap = "vim"`, `gg` jumps to the first line in the active pane, `G` jumps to the last line, and `qq` exits quickly
 
 ##### Background sync
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Inside the TUI:
 
 - `:` opens the command palette
 - the header shows the active keymap scheme (`default`, `vim`, or `custom`)
+- a numeric prefix repeats vertical movement: `count+i/k` for `default`/`custom`, `count+j/k` for `vim`
 - `y` / `n` enable or disable the selected subscription
 - `Enter` opens the selected mailbox or thread and moves focus to threads or preview
 - `a` applies the current patch series

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ criew tui
 Inside the TUI:
 
 - `:` opens the command palette
+- the header shows the active keymap scheme (`default`, `vim`, or `custom`)
 - `y` / `n` enable or disable the selected subscription
 - `Enter` opens the selected mailbox or thread
 - `a` applies the current patch series

--- a/docs/reference/config.example.toml
+++ b/docs/reference/config.example.toml
@@ -58,7 +58,7 @@ filter = "info"
 # Optional. Main-page navigation scheme.
 # Supported:
 #   "default" (j/l focus, i/k move)
-#   "vim" (h/l focus, j/k move)
+#   "vim" (h/l focus, j/k move, gg/G jump, qq quit)
 #   "custom" (header shows custom; navigation currently falls back to default bindings)
 # Default: "default"
 # keymap = "default"

--- a/docs/reference/config.example.toml
+++ b/docs/reference/config.example.toml
@@ -56,7 +56,10 @@ filter = "info"
 # startup_sync = true
 
 # Optional. Main-page navigation scheme.
-# Supported: "default" (j/l focus, i/k move), "vim" (h/l focus, j/k move).
+# Supported:
+#   "default" (j/l focus, i/k move)
+#   "vim" (h/l focus, j/k move)
+#   "custom" (header shows custom; navigation currently falls back to default bindings)
 # Default: "default"
 # keymap = "default"
 

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -31,7 +31,7 @@ mailbox = "linux-kernel"
 
 [ui]
 startup_sync = true
-# keymap = "default" # Supported: default, vim
+# keymap = "default" # Supported: default, vim, custom
 # inbox_auto_sync_interval_secs = 30
 
 [logging]
@@ -63,6 +63,7 @@ pub enum UiKeymap {
     #[default]
     Default,
     Vim,
+    Custom,
 }
 
 impl UiKeymap {
@@ -70,6 +71,7 @@ impl UiKeymap {
         match self {
             Self::Default => "default",
             Self::Vim => "vim",
+            Self::Custom => "custom",
         }
     }
 }
@@ -733,6 +735,27 @@ trees = ["./linux-next"]
         assert!(content.contains("mailbox = \"linux-kernel\""));
 
         let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn loads_custom_ui_keymap_from_config() {
+        let base = temp_dir("config-custom-keymap");
+        let config_path = base.join("config.toml");
+
+        fs::write(
+            &config_path,
+            r#"
+[ui]
+keymap = "custom"
+"#,
+        )
+        .expect("write config");
+
+        let loaded = load(Some(&config_path)).expect("load config");
+
+        assert_eq!(loaded.ui_keymap, UiKeymap::Custom);
+
+        let _ = fs::remove_dir_all(base);
     }
 
     #[test]

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -3029,6 +3029,7 @@ impl AppState {
                     format!("showing threads for {}", mailbox),
                     true,
                 );
+                self.focus = Pane::Threads;
             }
             Ok(_) => {
                 if self.mailbox_sync_pending(&mailbox) {
@@ -3038,6 +3039,7 @@ impl AppState {
                         format!("{mailbox} is syncing in background; page stays responsive"),
                         true,
                     );
+                    self.focus = Pane::Threads;
                     return;
                 }
 
@@ -3053,6 +3055,7 @@ impl AppState {
                     }
                 };
                 self.show_mailbox_threads(&mailbox, Vec::new(), background_status, true);
+                self.focus = Pane::Threads;
             }
             Err(error) => {
                 tracing::error!(

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -230,7 +230,7 @@ const CONFIG_EDITOR_FIELDS: &[ConfigEditorField] = &[
     },
     ConfigEditorField {
         key: "ui.keymap",
-        description: "Main-page navigation scheme. default=j/l focus+i/k move, vim=h/l focus+j/k move.",
+        description: "Main-page navigation scheme. default=j/l+i/k, vim=h/l+j/k, custom=default fallback with custom label.",
     },
     ConfigEditorField {
         key: "ui.inbox_auto_sync_interval_secs",
@@ -306,14 +306,14 @@ const EXTERNAL_EDITOR_ENTRY_HINT: &str = "select a source file in Source pane, t
 
 fn main_page_focus_shortcuts(keymap: UiKeymap) -> &'static str {
     match keymap {
-        UiKeymap::Default => "j/l",
+        UiKeymap::Default | UiKeymap::Custom => "j/l",
         UiKeymap::Vim => "h/l",
     }
 }
 
 fn main_page_move_shortcuts(keymap: UiKeymap) -> &'static str {
     match keymap {
-        UiKeymap::Default => "i/k",
+        UiKeymap::Default | UiKeymap::Custom => "i/k",
         UiKeymap::Vim => "j/k",
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -4,6 +4,7 @@
 //! machine stays here so key handling, background work, and side effects remain
 //! readable in one place.
 
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
@@ -230,7 +231,7 @@ const CONFIG_EDITOR_FIELDS: &[ConfigEditorField] = &[
     },
     ConfigEditorField {
         key: "ui.keymap",
-        description: "Main-page navigation scheme. default=j/l+i/k, vim=h/l+j/k, custom=default fallback with custom label.",
+        description: "Main-page navigation scheme. default=j/l+i/k, vim=h/l+j/k+gg/G+qq, custom=default fallback with custom label.",
     },
     ConfigEditorField {
         key: "ui.inbox_auto_sync_interval_secs",
@@ -337,6 +338,20 @@ type ExternalEditorRunner =
 type ReplyIdentityResolver = fn() -> std::result::Result<ReplyIdentity, String>;
 type ReplySendExecutor = fn(&RuntimeConfig, &SendRequest) -> SendOutcome;
 type MailboxSyncSpawner = fn(RuntimeConfig, Vec<String>) -> Receiver<StartupSyncEvent>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingMainPageChord {
+    VimGoToFirstLine,
+    VimQuit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingMainPageChordState {
+    chord: PendingMainPageChord,
+    ui_page: UiPage,
+    focus: Pane,
+    code_focus: CodePaneFocus,
+}
 
 #[derive(Debug, Clone)]
 enum StartupSyncEvent {
@@ -1204,6 +1219,7 @@ struct AppState {
     kernel_tree_expanded_paths: HashSet<PathBuf>,
     kernel_tree_row_index: usize,
     code_preview_scroll: u16,
+    code_preview_scroll_limit: Cell<u16>,
     code_edit_mode: CodeEditMode,
     code_edit_target: Option<PathBuf>,
     code_edit_buffer: Vec<String>,
@@ -1214,6 +1230,7 @@ struct AppState {
     reply_panel: Option<ReplyPanelState>,
     thread_index: usize,
     preview_scroll: u16,
+    preview_scroll_limit: Cell<u16>,
     selected_mail_preview: Option<MailPreview>,
     started_at: Instant,
     status: String,
@@ -1231,6 +1248,7 @@ struct AppState {
     inbox_auto_sync: Option<InboxAutoSyncState>,
     manual_sync: Option<ManualSyncState>,
     subscription_auto_sync: Option<SubscriptionAutoSyncState>,
+    pending_main_page_chord: Option<PendingMainPageChordState>,
 }
 
 impl AppState {
@@ -1317,6 +1335,7 @@ impl AppState {
             kernel_tree_expanded_paths,
             kernel_tree_row_index: 0,
             code_preview_scroll: 0,
+            code_preview_scroll_limit: Cell::new(u16::MAX),
             code_edit_mode: CodeEditMode::Browse,
             code_edit_target: None,
             code_edit_buffer: Vec::new(),
@@ -1327,6 +1346,7 @@ impl AppState {
             reply_panel: None,
             thread_index: 0,
             preview_scroll: 0,
+            preview_scroll_limit: Cell::new(u16::MAX),
             selected_mail_preview: None,
             started_at: Instant::now(),
             status: String::new(),
@@ -1344,6 +1364,7 @@ impl AppState {
             inbox_auto_sync: None,
             manual_sync: None,
             subscription_auto_sync: None,
+            pending_main_page_chord: None,
         };
         if state.runtime.imap.is_complete() {
             state.imap_defaults_initialized = true;
@@ -3635,13 +3656,19 @@ impl AppState {
                     }
                 }
                 Pane::Preview => {
-                    self.preview_scroll = self.preview_scroll.saturating_sub(1);
+                    self.preview_scroll = self
+                        .preview_scroll
+                        .min(self.preview_scroll_limit.get())
+                        .saturating_sub(1);
                 }
             },
             UiPage::CodeBrowser => match self.code_focus {
                 CodePaneFocus::Tree => self.move_kernel_tree_up(),
                 CodePaneFocus::Source => {
-                    self.code_preview_scroll = self.code_preview_scroll.saturating_sub(1);
+                    self.code_preview_scroll = self
+                        .code_preview_scroll
+                        .min(self.code_preview_scroll_limit.get())
+                        .saturating_sub(1);
                 }
             },
         }
@@ -3661,13 +3688,23 @@ impl AppState {
                     }
                 }
                 Pane::Preview => {
-                    self.preview_scroll = self.preview_scroll.saturating_add(1);
+                    let preview_scroll_limit = self.preview_scroll_limit.get();
+                    self.preview_scroll = self
+                        .preview_scroll
+                        .min(preview_scroll_limit)
+                        .saturating_add(1)
+                        .min(preview_scroll_limit);
                 }
             },
             UiPage::CodeBrowser => match self.code_focus {
                 CodePaneFocus::Tree => self.move_kernel_tree_down(),
                 CodePaneFocus::Source => {
-                    self.code_preview_scroll = self.code_preview_scroll.saturating_add(1);
+                    let code_preview_scroll_limit = self.code_preview_scroll_limit.get();
+                    self.code_preview_scroll = self
+                        .code_preview_scroll
+                        .min(code_preview_scroll_limit)
+                        .saturating_add(1)
+                        .min(code_preview_scroll_limit);
                 }
             },
         }
@@ -3677,6 +3714,96 @@ impl AppState {
         self.search.active = true;
         self.search.input = self.search.applied_query.clone();
         self.status = "search mode".to_string();
+    }
+
+    fn jump_current_pane_to_start(&mut self) {
+        match self.ui_page {
+            UiPage::Mail => match self.focus {
+                Pane::Subscriptions => {
+                    self.subscription_row_index = 0;
+                    self.clamp_subscription_row_selection();
+                }
+                Pane::Threads => {
+                    if !self.filtered_thread_indices.is_empty() {
+                        self.thread_index = 0;
+                        self.preview_scroll = 0;
+                        self.refresh_selected_mail_preview();
+                    }
+                }
+                Pane::Preview => {
+                    self.preview_scroll = 0;
+                }
+            },
+            UiPage::CodeBrowser => match self.code_focus {
+                CodePaneFocus::Tree => {
+                    let previous_file =
+                        self.selected_kernel_tree_file_path().map(Path::to_path_buf);
+                    self.kernel_tree_row_index = 0;
+                    let next_file = self.selected_kernel_tree_file_path().map(Path::to_path_buf);
+                    if previous_file != next_file {
+                        self.code_preview_scroll = 0;
+                    }
+                }
+                CodePaneFocus::Source => {
+                    self.code_preview_scroll = 0;
+                }
+            },
+        }
+    }
+
+    fn jump_current_pane_to_end(&mut self) {
+        match self.ui_page {
+            UiPage::Mail => match self.focus {
+                Pane::Subscriptions => {
+                    let rows = self.subscription_rows();
+                    if rows.is_empty() {
+                        return;
+                    }
+                    self.subscription_row_index = rows.len().saturating_sub(1);
+                    self.clamp_subscription_row_selection();
+                }
+                Pane::Threads => {
+                    if !self.filtered_thread_indices.is_empty() {
+                        self.thread_index = self.filtered_thread_indices.len().saturating_sub(1);
+                        self.preview_scroll = 0;
+                        self.refresh_selected_mail_preview();
+                    }
+                }
+                Pane::Preview => {
+                    self.preview_scroll = u16::MAX;
+                }
+            },
+            UiPage::CodeBrowser => match self.code_focus {
+                CodePaneFocus::Tree => {
+                    if self.kernel_tree_rows.is_empty() {
+                        self.kernel_tree_row_index = 0;
+                        return;
+                    }
+                    let previous_file =
+                        self.selected_kernel_tree_file_path().map(Path::to_path_buf);
+                    self.kernel_tree_row_index = self.kernel_tree_rows.len().saturating_sub(1);
+                    let next_file = self.selected_kernel_tree_file_path().map(Path::to_path_buf);
+                    if previous_file != next_file {
+                        self.code_preview_scroll = 0;
+                    }
+                }
+                CodePaneFocus::Source => {
+                    self.code_preview_scroll = self.code_preview_scroll_limit.get();
+                }
+            },
+        }
+    }
+
+    fn pending_main_page_chord_state(
+        &self,
+        chord: PendingMainPageChord,
+    ) -> PendingMainPageChordState {
+        PendingMainPageChordState {
+            chord,
+            ui_page: self.ui_page,
+            focus: self.focus,
+            code_focus: self.code_focus,
+        }
     }
 
     fn close_search(&mut self) {

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -231,7 +231,7 @@ const CONFIG_EDITOR_FIELDS: &[ConfigEditorField] = &[
     },
     ConfigEditorField {
         key: "ui.keymap",
-        description: "Main-page navigation scheme. default=j/l+i/k, vim=h/l+j/k+gg/G+qq, custom=default fallback with custom label.",
+        description: "Main-page navigation scheme. default=j/l+i/k+count, vim=h/l+j/k+count+gg/G+qq, custom=default fallback with custom label.",
     },
     ConfigEditorField {
         key: "ui.inbox_auto_sync_interval_secs",
@@ -348,6 +348,14 @@ enum PendingMainPageChord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PendingMainPageChordState {
     chord: PendingMainPageChord,
+    ui_page: UiPage,
+    focus: Pane,
+    code_focus: CodePaneFocus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingMainPageCountState {
+    count: u16,
     ui_page: UiPage,
     focus: Pane,
     code_focus: CodePaneFocus,
@@ -1249,6 +1257,7 @@ struct AppState {
     manual_sync: Option<ManualSyncState>,
     subscription_auto_sync: Option<SubscriptionAutoSyncState>,
     pending_main_page_chord: Option<PendingMainPageChordState>,
+    pending_main_page_count: Option<PendingMainPageCountState>,
 }
 
 impl AppState {
@@ -1365,6 +1374,7 @@ impl AppState {
             manual_sync: None,
             subscription_auto_sync: None,
             pending_main_page_chord: None,
+            pending_main_page_count: None,
         };
         if state.runtime.imap.is_complete() {
             state.imap_defaults_initialized = true;
@@ -3807,6 +3817,53 @@ impl AppState {
             focus: self.focus,
             code_focus: self.code_focus,
         }
+    }
+
+    fn pending_main_page_count_state(&self, count: u16) -> PendingMainPageCountState {
+        PendingMainPageCountState {
+            count,
+            ui_page: self.ui_page,
+            focus: self.focus,
+            code_focus: self.code_focus,
+        }
+    }
+
+    fn clear_pending_main_page_inputs(&mut self) {
+        self.pending_main_page_chord = None;
+        self.pending_main_page_count = None;
+    }
+
+    fn clear_pending_main_page_count(&mut self) {
+        self.pending_main_page_count = None;
+    }
+
+    fn has_pending_main_page_count(&self) -> bool {
+        self.pending_main_page_count.is_some_and(|state| {
+            state.ui_page == self.ui_page
+                && state.focus == self.focus
+                && state.code_focus == self.code_focus
+        })
+    }
+
+    fn push_pending_main_page_count_digit(&mut self, digit: u16) {
+        let next_count = self
+            .pending_main_page_count
+            .filter(|state| {
+                state.ui_page == self.ui_page
+                    && state.focus == self.focus
+                    && state.code_focus == self.code_focus
+            })
+            .map(|state| state.count.saturating_mul(10).saturating_add(digit))
+            .unwrap_or(digit);
+        self.pending_main_page_count = Some(self.pending_main_page_count_state(next_count));
+    }
+
+    fn take_pending_main_page_count(&mut self) -> Option<u16> {
+        let pending_state = self.pending_main_page_count.take()?;
+        let same_scope = pending_state.ui_page == self.ui_page
+            && pending_state.focus == self.focus
+            && pending_state.code_focus == self.code_focus;
+        same_scope.then_some(pending_state.count)
     }
 
     fn close_search(&mut self) {

--- a/src/ui/tui/config.rs
+++ b/src/ui/tui/config.rs
@@ -830,6 +830,7 @@ fn config_value_suggestions(state: &AppState, key: Option<&String>) -> Vec<Palet
         "ui.keymap" => [
             ("default", "j/l focus, i/k move"),
             ("vim", "h/l focus, j/k move"),
+            ("custom", "custom label with default navigation fallback"),
         ]
         .iter()
         .map(|(value, description)| PaletteSuggestion {

--- a/src/ui/tui/config.rs
+++ b/src/ui/tui/config.rs
@@ -829,7 +829,7 @@ fn config_value_suggestions(state: &AppState, key: Option<&String>) -> Vec<Palet
             .collect(),
         "ui.keymap" => [
             ("default", "j/l focus, i/k move"),
-            ("vim", "h/l focus, j/k move"),
+            ("vim", "h/l focus, j/k move, gg/G jump, qq quit"),
             ("custom", "custom label with default navigation fallback"),
         ]
         .iter()

--- a/src/ui/tui/input.rs
+++ b/src/ui/tui/input.rs
@@ -62,6 +62,58 @@ fn handle_main_page_navigation_key(state: &mut AppState, key: KeyEvent) -> bool 
     }
 }
 
+fn handle_vim_main_page_chord(state: &mut AppState, key: KeyEvent) -> Option<LoopAction> {
+    if !matches!(state.runtime.ui_keymap, UiKeymap::Vim) {
+        state.pending_main_page_chord = None;
+        return None;
+    }
+
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+    {
+        state.pending_main_page_chord = None;
+        return None;
+    }
+
+    if let Some(pending_state) = state.pending_main_page_chord.take() {
+        let same_scope = pending_state.ui_page == state.ui_page
+            && pending_state.focus == state.focus
+            && pending_state.code_focus == state.code_focus;
+        if same_scope {
+            match (pending_state.chord, key.code) {
+                (PendingMainPageChord::VimGoToFirstLine, KeyCode::Char('g')) => {
+                    state.jump_current_pane_to_start();
+                    return Some(LoopAction::Continue);
+                }
+                (PendingMainPageChord::VimQuit, KeyCode::Char('q')) => {
+                    return Some(LoopAction::Exit);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    match key.code {
+        KeyCode::Char('g') => {
+            state.pending_main_page_chord =
+                Some(state.pending_main_page_chord_state(PendingMainPageChord::VimGoToFirstLine));
+            Some(LoopAction::Continue)
+        }
+        KeyCode::Char('G') => {
+            state.jump_current_pane_to_end();
+            Some(LoopAction::Continue)
+        }
+        KeyCode::Char('q') => {
+            state.pending_main_page_chord =
+                Some(state.pending_main_page_chord_state(PendingMainPageChord::VimQuit));
+            state.status = "press qq to quit or use command palette quit/exit".to_string();
+            Some(LoopAction::Continue)
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopAction {
     tracing::debug!(
         key = ?key,
@@ -78,10 +130,12 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
     // Modal UI surfaces take precedence over the base page shortcuts so keys
     // keep local meaning while a dialog, editor, or search interaction is open.
     if state.config_editor.open {
+        state.pending_main_page_chord = None;
         return handle_config_editor_key_event(state, key);
     }
 
     if state.palette.open {
+        state.pending_main_page_chord = None;
         if is_palette_toggle(key) {
             state.close_palette();
             return LoopAction::Continue;
@@ -90,15 +144,22 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
     }
 
     if state.search.active {
+        state.pending_main_page_chord = None;
         return handle_search_key_event(state, key);
     }
 
     if state.reply_panel.is_some() {
+        state.pending_main_page_chord = None;
         return handle_reply_key_event(state, key);
     }
 
     if state.is_code_edit_active() {
+        state.pending_main_page_chord = None;
         return handle_code_edit_key_event(state, key);
+    }
+
+    if let Some(action) = handle_vim_main_page_chord(state, key) {
+        return action;
     }
 
     if is_palette_open_shortcut(key) {

--- a/src/ui/tui/input.rs
+++ b/src/ui/tui/input.rs
@@ -19,47 +19,89 @@ pub(super) enum LoopAction {
     Restart,
 }
 
+fn pending_main_page_move_count(state: &mut AppState) -> u16 {
+    state.take_pending_main_page_count().unwrap_or(1)
+}
+
 fn handle_main_page_navigation_key(state: &mut AppState, key: KeyEvent) -> bool {
     match state.runtime.ui_keymap {
         UiKeymap::Default | UiKeymap::Custom => match key.code {
             KeyCode::Char('j') => {
+                state.clear_pending_main_page_count();
                 state.move_focus_previous();
                 true
             }
             KeyCode::Char('l') => {
+                state.clear_pending_main_page_count();
                 state.move_focus_next();
                 true
             }
             KeyCode::Char('i') => {
-                state.move_up();
+                for _ in 0..pending_main_page_move_count(state) {
+                    state.move_up();
+                }
                 true
             }
             KeyCode::Char('k') => {
-                state.move_down();
+                for _ in 0..pending_main_page_move_count(state) {
+                    state.move_down();
+                }
                 true
             }
             _ => false,
         },
         UiKeymap::Vim => match key.code {
             KeyCode::Char('h') => {
+                state.clear_pending_main_page_count();
                 state.move_focus_previous();
                 true
             }
             KeyCode::Char('l') => {
+                state.clear_pending_main_page_count();
                 state.move_focus_next();
                 true
             }
             KeyCode::Char('k') => {
-                state.move_up();
+                for _ in 0..pending_main_page_move_count(state) {
+                    state.move_up();
+                }
                 true
             }
             KeyCode::Char('j') => {
-                state.move_down();
+                for _ in 0..pending_main_page_move_count(state) {
+                    state.move_down();
+                }
                 true
             }
             _ => false,
         },
     }
+}
+
+fn handle_main_page_count_prefix(state: &mut AppState, key: KeyEvent) -> bool {
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+    {
+        state.clear_pending_main_page_count();
+        return false;
+    }
+
+    let KeyCode::Char(character) = key.code else {
+        return false;
+    };
+    if !character.is_ascii_digit() {
+        return false;
+    }
+    if character == '0' && !state.has_pending_main_page_count() {
+        return false;
+    }
+
+    let digit = character
+        .to_digit(10)
+        .expect("ascii digit should convert to decimal") as u16;
+    state.push_pending_main_page_count_digit(digit);
+    true
 }
 
 fn handle_vim_main_page_chord(state: &mut AppState, key: KeyEvent) -> Option<LoopAction> {
@@ -72,7 +114,7 @@ fn handle_vim_main_page_chord(state: &mut AppState, key: KeyEvent) -> Option<Loo
         .modifiers
         .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
     {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         return None;
     }
 
@@ -96,15 +138,18 @@ fn handle_vim_main_page_chord(state: &mut AppState, key: KeyEvent) -> Option<Loo
 
     match key.code {
         KeyCode::Char('g') => {
+            state.clear_pending_main_page_count();
             state.pending_main_page_chord =
                 Some(state.pending_main_page_chord_state(PendingMainPageChord::VimGoToFirstLine));
             Some(LoopAction::Continue)
         }
         KeyCode::Char('G') => {
+            state.clear_pending_main_page_count();
             state.jump_current_pane_to_end();
             Some(LoopAction::Continue)
         }
         KeyCode::Char('q') => {
+            state.clear_pending_main_page_count();
             state.pending_main_page_chord =
                 Some(state.pending_main_page_chord_state(PendingMainPageChord::VimQuit));
             state.status = "press qq to quit or use command palette quit/exit".to_string();
@@ -130,12 +175,12 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
     // Modal UI surfaces take precedence over the base page shortcuts so keys
     // keep local meaning while a dialog, editor, or search interaction is open.
     if state.config_editor.open {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         return handle_config_editor_key_event(state, key);
     }
 
     if state.palette.open {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         if is_palette_toggle(key) {
             state.close_palette();
             return LoopAction::Continue;
@@ -144,17 +189,17 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
     }
 
     if state.search.active {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         return handle_search_key_event(state, key);
     }
 
     if state.reply_panel.is_some() {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         return handle_reply_key_event(state, key);
     }
 
     if state.is_code_edit_active() {
-        state.pending_main_page_chord = None;
+        state.clear_pending_main_page_inputs();
         return handle_code_edit_key_event(state, key);
     }
 
@@ -162,7 +207,12 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
         return action;
     }
 
+    if handle_main_page_count_prefix(state, key) {
+        return LoopAction::Continue;
+    }
+
     if is_palette_open_shortcut(key) {
+        state.clear_pending_main_page_count();
         state.toggle_palette();
         return LoopAction::Continue;
     }
@@ -170,6 +220,8 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
     if handle_main_page_navigation_key(state, key) {
         return LoopAction::Continue;
     }
+
+    state.clear_pending_main_page_count();
 
     match key.code {
         KeyCode::Char('/') => {

--- a/src/ui/tui/input.rs
+++ b/src/ui/tui/input.rs
@@ -21,7 +21,7 @@ pub(super) enum LoopAction {
 
 fn handle_main_page_navigation_key(state: &mut AppState, key: KeyEvent) -> bool {
     match state.runtime.ui_keymap {
-        UiKeymap::Default => match key.code {
+        UiKeymap::Default | UiKeymap::Custom => match key.code {
             KeyCode::Char('j') => {
                 state.move_focus_previous();
                 true

--- a/src/ui/tui/input.rs
+++ b/src/ui/tui/input.rs
@@ -237,6 +237,7 @@ pub(super) fn handle_key_event(state: &mut AppState, key: KeyEvent) -> LoopActio
                 Pane::Threads => {
                     if let Some(thread) = state.selected_thread() {
                         state.status = format!("selected {}", thread.message_id);
+                        state.focus = Pane::Preview;
                     }
                 }
                 Pane::Preview => {}

--- a/src/ui/tui/render.rs
+++ b/src/ui/tui/render.rs
@@ -22,6 +22,12 @@ use super::*;
 const REPLY_BODY_GUIDE_COLUMN: usize = 80;
 const HEADER_BG: Color = Color::Blue;
 
+#[derive(Clone, Copy)]
+enum VerticalScrollWrapMode {
+    Disabled,
+    Enabled,
+}
+
 pub(super) fn draw(
     frame: &mut Frame<'_>,
     state: &AppState,
@@ -355,8 +361,24 @@ fn draw_code_source_preview(frame: &mut Frame<'_>, area: Rect, state: &AppState)
     frame.render_widget(block, area);
     frame.render_widget(Clear, inner_area);
 
-    let paragraph =
-        Paragraph::new(load_code_source_preview(state)).scroll((state.code_preview_scroll, 0));
+    let preview = load_code_source_preview(state);
+    let code_preview_scroll_limit = max_vertical_scroll(
+        &preview,
+        inner_area.width,
+        inner_area.height,
+        VerticalScrollWrapMode::Disabled,
+    );
+    state
+        .code_preview_scroll_limit
+        .set(code_preview_scroll_limit);
+    let scroll = clamp_vertical_scroll(
+        &preview,
+        inner_area.width,
+        inner_area.height,
+        state.code_preview_scroll,
+        VerticalScrollWrapMode::Disabled,
+    );
+    let paragraph = Paragraph::new(preview).scroll((scroll, 0));
     frame.render_widget(paragraph, inner_area);
 
     if let Some(cursor_position) = code_edit_cursor_position(state, inner_area) {
@@ -566,11 +588,83 @@ fn draw_preview(frame: &mut Frame<'_>, area: Rect, state: &AppState, config: &Ru
         inner_area
     };
 
+    let preview_scroll_limit = max_vertical_scroll(
+        preview.as_ref(),
+        content_area.width,
+        content_area.height,
+        VerticalScrollWrapMode::Enabled,
+    );
+    state.preview_scroll_limit.set(preview_scroll_limit);
+    let scroll = clamp_vertical_scroll(
+        preview.as_ref(),
+        content_area.width,
+        content_area.height,
+        state.preview_scroll,
+        VerticalScrollWrapMode::Enabled,
+    );
     let paragraph = Paragraph::new(preview.as_ref())
-        .scroll((state.preview_scroll, 0))
+        .scroll((scroll, 0))
         .wrap(Wrap { trim: false });
 
     frame.render_widget(paragraph, content_area);
+}
+
+fn clamp_vertical_scroll(
+    text: &str,
+    area_width: u16,
+    area_height: u16,
+    requested_scroll: u16,
+    wrap_mode: VerticalScrollWrapMode,
+) -> u16 {
+    requested_scroll.min(max_vertical_scroll(
+        text,
+        area_width,
+        area_height,
+        wrap_mode,
+    ))
+}
+
+fn max_vertical_scroll(
+    text: &str,
+    area_width: u16,
+    area_height: u16,
+    wrap_mode: VerticalScrollWrapMode,
+) -> u16 {
+    if area_height == 0 {
+        return 0;
+    }
+
+    let visible_lines = area_height as usize;
+    let total_lines = visual_line_count(text, area_width, wrap_mode);
+    total_lines
+        .saturating_sub(visible_lines)
+        .min(u16::MAX as usize) as u16
+}
+
+fn visual_line_count(text: &str, area_width: u16, wrap_mode: VerticalScrollWrapMode) -> usize {
+    match wrap_mode {
+        VerticalScrollWrapMode::Disabled => text.split('\n').count().max(1),
+        VerticalScrollWrapMode::Enabled => {
+            if area_width == 0 {
+                return 0;
+            }
+
+            text.split('\n')
+                .map(|line| wrapped_visual_line_count(line, area_width))
+                .sum::<usize>()
+                .max(1)
+        }
+    }
+}
+
+fn wrapped_visual_line_count(line: &str, area_width: u16) -> usize {
+    if area_width == 0 {
+        return 0;
+    }
+
+    let width = area_width as usize;
+    let display_width = display_column(line, line.chars().count()).max(1);
+    display_width.saturating_add(width - 1) / width
 }
 
 fn load_series_preview(state: &AppState, config: &RuntimeConfig, thread_id: i64) -> Option<String> {

--- a/src/ui/tui/render.rs
+++ b/src/ui/tui/render.rs
@@ -91,6 +91,14 @@ pub(super) fn draw(
         ),
         Span::styled(" | ", Style::default().fg(Color::White).bg(HEADER_BG)),
         Span::styled(
+            format!("keymap {}", state.runtime.ui_keymap.as_str()),
+            Style::default()
+                .fg(Color::White)
+                .bg(HEADER_BG)
+                .add_modifier(Modifier::DIM),
+        ),
+        Span::styled(" | ", Style::default().fg(Color::White).bg(HEADER_BG)),
+        Span::styled(
             format!("up {}s", uptime),
             Style::default()
                 .fg(Color::White)

--- a/src/ui/tui/tests.rs
+++ b/src/ui/tui/tests.rs
@@ -3559,10 +3559,27 @@ fn header_shows_criew_brand_and_default_footer_hides_empty_status() {
     assert!(rendered.contains("CRIEW"));
     assert!(rendered.contains(env!("CARGO_PKG_VERSION")));
     assert!(rendered.contains("Mail / inbox"));
+    assert!(rendered.contains("keymap default"));
     assert!(!rendered.contains("db schema"));
     assert!(!rendered.contains("db:"));
     assert!(!rendered.contains("status:"));
     assert!(!rendered.contains(" ready "));
+}
+
+#[test]
+fn header_shows_custom_keymap_scheme_when_configured() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Custom;
+    let bootstrap = test_bootstrap(&runtime);
+    let state = AppState::new(vec![], runtime.clone());
+
+    let mut terminal = Terminal::new(TestBackend::new(140, 35)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw custom keymap header");
+    let rendered = format!("{}", terminal.backend());
+
+    assert!(rendered.contains("keymap custom"));
 }
 
 #[test]

--- a/src/ui/tui/tests.rs
+++ b/src/ui/tui/tests.rs
@@ -82,6 +82,16 @@ fn sample_thread_with_raw(
     }
 }
 
+fn sample_threads(count: usize) -> Vec<ThreadRow> {
+    (0..count)
+        .map(|index| {
+            let subject = format!("t{index}");
+            let message_id = format!("{index}@example.com");
+            sample_thread(&subject, &message_id, index as u16)
+        })
+        .collect()
+}
+
 fn sample_thread_in_thread(
     thread_id: i64,
     mail_id: i64,
@@ -1033,6 +1043,105 @@ fn loaded_vim_keymap_drives_navigation_keys() {
         matches!(state.focus, Pane::Subscriptions),
         "h should move focus left in vim keymap"
     );
+}
+
+#[test]
+fn default_keymap_supports_counted_ik_navigation() {
+    let mut state = AppState::new(sample_threads(15), test_runtime());
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    assert!(matches!(state.focus, Pane::Threads));
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE),
+    );
+    let action_down = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_down, LoopAction::Continue));
+    assert_eq!(state.thread_index, 12);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+    );
+    let action_up = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_up, LoopAction::Continue));
+    assert_eq!(state.thread_index, 7);
+}
+
+#[test]
+fn vim_keymap_supports_counted_jk_navigation() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Vim;
+    let mut state = AppState::new(sample_threads(15), runtime);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    assert!(matches!(state.focus, Pane::Threads));
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE),
+    );
+    let action_down = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_down, LoopAction::Continue));
+    assert_eq!(state.thread_index, 12);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+    );
+    let action_up = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_up, LoopAction::Continue));
+    assert_eq!(state.thread_index, 7);
+}
+
+#[test]
+fn counted_main_page_navigation_does_not_leak_into_focus_changes() {
+    let mut state = AppState::new(sample_threads(4), test_runtime());
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE),
+    );
+    let focus_action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    assert!(matches!(focus_action, LoopAction::Continue));
+    assert!(matches!(state.focus, Pane::Threads));
+
+    let move_action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+    );
+    assert!(matches!(move_action, LoopAction::Continue));
+    assert_eq!(state.thread_index, 1);
 }
 
 #[test]

--- a/src/ui/tui/tests.rs
+++ b/src/ui/tui/tests.rs
@@ -949,6 +949,8 @@ keymap = "default"
     let rendered = format!("{}", terminal.backend());
     assert!(rendered.contains("h/l focus | j/k move"));
     assert!(!rendered.contains("j/l focus | i/k move"));
+    assert!(!rendered.contains("gg/G jump"));
+    assert!(!rendered.contains("qq quit"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -1031,6 +1033,423 @@ fn loaded_vim_keymap_drives_navigation_keys() {
         matches!(state.focus, Pane::Subscriptions),
         "h should move focus left in vim keymap"
     );
+}
+
+#[test]
+fn vim_keymap_supports_gg_and_capital_g_jumps_on_mail_panes() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Vim;
+    let mut state = AppState::new(
+        vec![
+            sample_thread("t0", "a@example.com", 0),
+            sample_thread("t1", "b@example.com", 1),
+            sample_thread("t2", "c@example.com", 2),
+        ],
+        runtime,
+    );
+
+    let subscription_rows = state.subscription_rows();
+    assert!(!subscription_rows.is_empty());
+
+    let action_bottom = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action_bottom, LoopAction::Continue));
+    assert_eq!(
+        state.subscription_row_index,
+        subscription_rows.len().saturating_sub(1)
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    let action_top = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_top, LoopAction::Continue));
+    assert_eq!(state.subscription_row_index, 0);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    let action_thread_bottom = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action_thread_bottom, LoopAction::Continue));
+    assert_eq!(state.thread_index, 2);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    let action_thread_top = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_thread_top, LoopAction::Continue));
+    assert_eq!(state.thread_index, 0);
+
+    state.focus = Pane::Preview;
+    state.preview_scroll = 7;
+    let action_preview_bottom = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action_preview_bottom, LoopAction::Continue));
+    assert_eq!(state.preview_scroll, u16::MAX);
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    let action_preview_top = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_preview_top, LoopAction::Continue));
+    assert_eq!(state.preview_scroll, 0);
+}
+
+#[test]
+fn vim_keymap_supports_gg_and_capital_g_jumps_in_code_browser() {
+    let tree_root = temp_dir("vim-jump-code-browser");
+    let file_path = tree_root.join("demo.c");
+    let source = (1..=40)
+        .map(|line| format!("int line_{line} = {line};"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&file_path, format!("{source}\n")).expect("write file");
+
+    let mut runtime = test_runtime_with_kernel_tree(tree_root.clone());
+    runtime.ui_keymap = UiKeymap::Vim;
+    let bootstrap = test_bootstrap(&runtime);
+    let mut state = AppState::new(vec![], runtime.clone());
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert!(matches!(state.ui_page, UiPage::CodeBrowser));
+
+    let action_tree_bottom = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action_tree_bottom, LoopAction::Continue));
+    assert_eq!(
+        state.kernel_tree_row_index,
+        state.kernel_tree_rows.len().saturating_sub(1)
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    let action_tree_top = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_tree_top, LoopAction::Continue));
+    assert_eq!(state.kernel_tree_row_index, 0);
+
+    state.code_focus = CodePaneFocus::Source;
+    state.kernel_tree_row_index = state
+        .kernel_tree_rows
+        .iter()
+        .position(|row| row.path == file_path)
+        .expect("file row exists");
+
+    let mut terminal = Terminal::new(TestBackend::new(140, 18)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw source preview before vim jumps");
+
+    state.code_preview_scroll = 9;
+    let action_source_bottom = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action_source_bottom, LoopAction::Continue));
+    let code_preview_scroll_limit = state.code_preview_scroll_limit.get();
+    assert!(code_preview_scroll_limit > 0);
+    assert_eq!(state.code_preview_scroll, code_preview_scroll_limit);
+
+    let action_source_up = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_source_up, LoopAction::Continue));
+    assert_eq!(
+        state.code_preview_scroll,
+        code_preview_scroll_limit.saturating_sub(1)
+    );
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    let action_source_top = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(action_source_top, LoopAction::Continue));
+    assert_eq!(state.code_preview_scroll, 0);
+
+    let _ = fs::remove_dir_all(tree_root);
+}
+
+#[test]
+fn vim_keymap_supports_qq_quit_chord() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Vim;
+    let mut state = AppState::new(vec![], runtime);
+
+    let first = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+    );
+    assert!(matches!(first, LoopAction::Continue));
+    assert_eq!(
+        state.status,
+        "press qq to quit or use command palette quit/exit"
+    );
+
+    let second = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+    );
+    assert!(matches!(second, LoopAction::Exit));
+}
+
+#[test]
+fn vim_chords_do_not_leak_into_right_preview_pane() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Vim;
+    let mut state = AppState::new(
+        vec![
+            sample_thread("t0", "a@example.com", 0),
+            sample_thread("t1", "b@example.com", 1),
+        ],
+        runtime,
+    );
+
+    let arm_quit = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+    );
+    assert!(matches!(arm_quit, LoopAction::Continue));
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
+    );
+    assert!(matches!(state.focus, Pane::Preview));
+
+    state.preview_scroll = 11;
+    let first_g = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(first_g, LoopAction::Continue));
+    assert_eq!(state.preview_scroll, 11);
+
+    let second_g = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+    );
+    assert!(matches!(second_g, LoopAction::Continue));
+    assert_eq!(state.preview_scroll, 0);
+}
+
+#[test]
+fn preview_pane_shift_g_keeps_tui_renderable() {
+    let mut runtime = test_runtime();
+    runtime.ui_keymap = UiKeymap::Vim;
+    let bootstrap = test_bootstrap(&runtime);
+    let mut state = AppState::new(
+        vec![sample_thread("preview thread", "preview@example.com", 0)],
+        runtime.clone(),
+    );
+    state.focus = Pane::Preview;
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action, LoopAction::Continue));
+
+    let mut terminal = Terminal::new(TestBackend::new(140, 35)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw after preview shift-g");
+    let rendered = format!("{}", terminal.backend());
+
+    assert!(rendered.contains("Preview"));
+}
+
+#[test]
+fn preview_pane_can_move_up_after_reaching_bottom() {
+    let root = temp_dir("preview-scroll-bottom");
+    let raw_path = root.join("preview.eml");
+    let body = (1..=40)
+        .map(|line| format!("preview line {line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        &raw_path,
+        format!(
+            "Message-ID: <preview-scroll@example.com>\r\nSubject: preview scroll\r\nFrom: preview@example.com\r\n\r\n{body}\n"
+        ),
+    )
+    .expect("write raw mail");
+
+    let runtime = test_runtime();
+    let bootstrap = test_bootstrap(&runtime);
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "preview scroll",
+            "preview-scroll@example.com",
+            0,
+            raw_path.clone(),
+        )],
+        runtime.clone(),
+    );
+    state.focus = Pane::Preview;
+
+    let mut terminal = Terminal::new(TestBackend::new(120, 16)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw initial preview frame");
+
+    let preview_scroll_limit = state.preview_scroll_limit.get();
+    assert!(preview_scroll_limit > 0);
+
+    for _ in 0..(preview_scroll_limit as usize + 10) {
+        let _ = handle_key_event(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        );
+    }
+    assert_eq!(state.preview_scroll, preview_scroll_limit);
+
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw bottom preview frame");
+    let bottom_frame = format!("{}", terminal.backend());
+
+    let _ = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+    );
+    assert_eq!(state.preview_scroll, preview_scroll_limit.saturating_sub(1));
+
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw preview frame after moving up");
+    let after_up_frame = format!("{}", terminal.backend());
+
+    assert_ne!(after_up_frame, bottom_frame);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn preview_scroll_limit_accounts_for_wrapped_long_lines() {
+    let root = temp_dir("preview-wrap-scroll");
+    let raw_path = root.join("wrapped-preview.eml");
+    let wrapped_body = format!("{} WRAP_TAIL_TOKEN\n", "x".repeat(380));
+    fs::write(
+        &raw_path,
+        format!(
+            "Message-ID: <wrapped-preview@example.com>\r\nSubject: wrapped preview\r\nFrom: preview@example.com\r\n\r\n{wrapped_body}"
+        ),
+    )
+    .expect("write wrapped preview mail");
+
+    let runtime = test_runtime();
+    let bootstrap = test_bootstrap(&runtime);
+    let mut state = AppState::new(
+        vec![sample_thread_with_raw(
+            "wrapped preview",
+            "wrapped-preview@example.com",
+            0,
+            raw_path.clone(),
+        )],
+        runtime.clone(),
+    );
+    state.focus = Pane::Preview;
+
+    let mut terminal = Terminal::new(TestBackend::new(40, 10)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw wrapped preview");
+    let top_frame = format!("{}", terminal.backend());
+    let preview_scroll_limit = state.preview_scroll_limit.get();
+    assert!(preview_scroll_limit > 0);
+    assert!(!top_frame.contains("WRAP_TAIL_TOKEN"));
+
+    for _ in 0..(preview_scroll_limit as usize + 5) {
+        let _ = handle_key_event(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        );
+    }
+
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw wrapped preview after scrolling");
+    let bottom_frame = format!("{}", terminal.backend());
+
+    assert!(bottom_frame.contains("WRAP_TAIL_TOKEN"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn source_pane_shift_g_keeps_tui_renderable() {
+    let tree_root = temp_dir("source-pane-shift-g");
+    let file_path = tree_root.join("demo.c");
+    fs::write(
+        &file_path,
+        "int line_1;\nint line_2;\nint line_3;\nint line_4;\nint line_5;\n",
+    )
+    .expect("write source file");
+
+    let mut runtime = test_runtime_with_kernel_tree(tree_root.clone());
+    runtime.ui_keymap = UiKeymap::Vim;
+    let bootstrap = test_bootstrap(&runtime);
+    let mut state = AppState::new(vec![], runtime.clone());
+
+    let _ = handle_key_event(&mut state, KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+    assert!(matches!(state.ui_page, UiPage::CodeBrowser));
+    state.code_focus = CodePaneFocus::Source;
+    state.kernel_tree_row_index = state
+        .kernel_tree_rows
+        .iter()
+        .position(|row| row.path == file_path)
+        .expect("file row exists");
+
+    let action = handle_key_event(
+        &mut state,
+        KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+    );
+    assert!(matches!(action, LoopAction::Continue));
+
+    let mut terminal = Terminal::new(TestBackend::new(140, 35)).expect("create test terminal");
+    terminal
+        .draw(|frame| draw(frame, &state, &runtime, &bootstrap))
+        .expect("draw after source shift-g");
+    let rendered = format!("{}", terminal.backend());
+
+    assert!(rendered.contains("Source Preview"));
+
+    let _ = fs::remove_dir_all(tree_root);
 }
 
 #[test]

--- a/src/ui/tui/tests.rs
+++ b/src/ui/tui/tests.rs
@@ -2745,10 +2745,35 @@ fn code_browser_navigation_keys_unchanged_when_not_editing() {
 }
 
 #[test]
-fn enter_on_subscription_opens_threads_without_toggling_enabled_state() {
-    let mut state = AppState::new(vec![], test_runtime());
+fn enter_on_subscription_opens_threads_and_focuses_threads_pane_without_toggling_enabled_state() {
+    let root = temp_dir("enter-open-subscription");
+    let runtime = test_runtime_with_imap_in(root.clone());
+    seed_mailbox_thread(
+        &runtime.database_path,
+        "io-uring",
+        1,
+        "io-uring@example.com",
+        "io-uring thread",
+    );
+
+    let mut state = AppState::new_with_ui_state(
+        vec![],
+        runtime,
+        Some(UiState {
+            enabled_mailboxes: vec![IMAP_INBOX_MAILBOX.to_string(), "io-uring".to_string()],
+            active_mailbox: Some(IMAP_INBOX_MAILBOX.to_string()),
+            ..UiState::default()
+        }),
+    );
     state.focus = Pane::Subscriptions;
-    let initial = state.subscriptions[0].enabled;
+    let io_uring_index = state
+        .subscriptions
+        .iter()
+        .position(|item| item.mailbox == "io-uring")
+        .expect("io-uring subscription exists");
+    state.subscription_index = io_uring_index;
+    state.sync_subscription_row_to_selected_item();
+    let initial = state.subscriptions[io_uring_index].enabled;
 
     let action = handle_key_event(
         &mut state,
@@ -2756,7 +2781,12 @@ fn enter_on_subscription_opens_threads_without_toggling_enabled_state() {
     );
 
     assert!(matches!(action, LoopAction::Continue));
-    assert_eq!(state.subscriptions[0].enabled, initial);
+    assert_eq!(state.subscriptions[io_uring_index].enabled, initial);
+    assert!(matches!(state.focus, Pane::Threads));
+    assert_eq!(state.active_thread_mailbox, "io-uring");
+    assert_eq!(state.threads.len(), 1);
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3091,6 +3121,7 @@ fn opening_empty_inbox_queues_background_sync_and_defers_next_auto_sync_tick() {
     assert!(state.threads.is_empty());
     assert!(state.status.contains("syncing in background"));
     assert!(state.manual_sync.is_some());
+    assert!(matches!(state.focus, Pane::Threads));
     assert!(
         state
             .inbox_auto_sync
@@ -3341,6 +3372,7 @@ fn enter_on_mailbox_pending_startup_sync_stays_non_blocking() {
     state.open_threads_for_selected_subscription();
 
     assert_eq!(state.active_thread_mailbox, IMAP_INBOX_MAILBOX);
+    assert!(matches!(state.focus, Pane::Threads));
     assert!(state.threads.is_empty());
     assert!(state.status.contains("syncing in background"));
 
@@ -3700,7 +3732,7 @@ fn palette_bang_reports_empty_local_command() {
 }
 
 #[test]
-fn enter_on_thread_sets_selected_status_message() {
+fn enter_on_thread_focuses_preview_and_sets_selected_status_message() {
     let mut state = AppState::new(
         vec![sample_thread("normal mail", "plain@example.com", 0)],
         test_runtime(),
@@ -3713,6 +3745,7 @@ fn enter_on_thread_sets_selected_status_message() {
     );
 
     assert!(matches!(action, LoopAction::Continue));
+    assert!(matches!(state.focus, Pane::Preview));
     assert_eq!(state.status, "selected plain@example.com");
 }
 


### PR DESCRIPTION
Optimize the panne selection logic. When an item in the upper-level panne is selected and the Enter key is pressed, the border of the lower-level panne will be highlighted and the content will be refreshed.
Add more key mappings in vim mode, such as gg/G to jump to the beginning/end of a line, qq to exit self.
Add more key mapping in vim mode, such as muber + j/k jump special line.